### PR TITLE
fix: use dynamic discovery in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for integration tests."""
 
 import os
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 import pytest
 import pytest_asyncio
@@ -31,7 +31,5 @@ async def authenticated_client(api_key: str) -> AsyncIterator[PretorianClient]:
         yield client
 
 
-# Common test data
+# Common test data - framework ID is stable
 KNOWN_FRAMEWORK_ID = "nist-800-53-r5"
-KNOWN_CONTROL_ID = "ac-1"
-KNOWN_FAMILY_ID = "ac"


### PR DESCRIPTION
## Summary

- Integration tests were hardcoding family IDs (`ac`) and control IDs (`ac-1`) that don't match the actual API format (slug-style IDs like `access-control`)
- Tests now discover valid IDs from the API at runtime instead of hardcoding them
- Fixed MCP resource URI comparison (`AnyUrl` object vs string)
- Changed family assertion to match by title ("access control") instead of short code ("ac")

## Failing tests fixed

| Test | Issue |
|------|-------|
| `test_list_controls_with_family_filter` | Family ID "ac" → discovered from API |
| `test_get_control` | Control ID "ac-1" → discovered from API |
| `test_get_control_with_references` | Same control ID issue |
| `test_list_control_families_includes_ac_family` | Short code → title match |
| `test_list_controls_with_family_filter` (MCP) | Family ID → discovered |
| `test_get_control_returns_details` (MCP) | Control ID → discovered |
| `test_get_control_references_returns_data` (MCP) | Control ID → discovered |
| `test_mcp_server_resources_listed` | `AnyUrl` → `str()` conversion |

## Test plan

- [ ] All 6 non-integration CI checks pass
- [ ] Integration tests pass on merge to master

🤖 Generated with [Claude Code](https://claude.ai/code)