### PR TITLE
fix: increase HTTP client timeout to 60s

### DIFF
--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -89,7 +89,7 @@ class PretorianClient:
             self._client = httpx.AsyncClient(
                 base_url=self._api_base_url,
                 headers=self._get_headers(),
-                timeout=30.0,
+                timeout=60.0,
             )
         return self._client
 


### PR DESCRIPTION
## Summary

- Increase httpx client timeout from 30s to 60s
- The control references endpoint can be slow, causing `ReadTimeout` errors in CI

One-line fix — all other CI checks already pass.

🤖 Generated with [Claude Code](https://claude.ai/code)