### PR TITLE
Fix URLs, restructure README with MCP as hero section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,4 @@ Please use GitHub Issues to report bugs or request features. Include:
 
 ## Questions?
 
-For questions about the API or platform, see [docs.pretorin.com](https://docs.pretorin.com).
+For questions about the API or platform, see [platform.pretorin.com/api/docs](https://platform.pretorin.com/api/docs).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CLI and MCP server for the Pretorin Compliance Platform API.
 
 Access compliance frameworks, control families, and control details from NIST 800-53, NIST 800-171, FedRAMP, CMMC, and more.
 
-**Documentation**: [https://docs.pretorin.com](https://docs.pretorin.com)
+**Documentation**: [https://platform.pretorin.com/api/docs](https://platform.pretorin.com/api/docs)
 
 ## Installation
 
@@ -54,9 +54,7 @@ pretorin update
 
 ## Quick Start
 
-### Authentication
-
-Get your API key from [https://platform.pretorin.com/settings/developer](https://platform.pretorin.com/settings/developer), then:
+Get your API key from [https://platform.pretorin.com/](https://platform.pretorin.com/), then authenticate:
 
 ```bash
 pretorin login
@@ -68,140 +66,126 @@ Verify your authentication:
 pretorin whoami
 ```
 
-### Browse Frameworks
-
-List all available compliance frameworks:
-
-```bash
-pretorin frameworks list
-```
-
-Get details about a specific framework:
-
-```bash
-pretorin frameworks get nist-800-53-r5
-```
-
-### Browse Control Families
-
-List control families for a framework:
-
-```bash
-pretorin frameworks families nist-800-53-r5
-```
-
-### Browse Controls
-
-List all controls for a framework:
-
-```bash
-pretorin frameworks controls nist-800-53-r5
-```
-
-Filter by control family:
-
-```bash
-pretorin frameworks controls nist-800-53-r5 --family ac
-```
-
-Get details of a specific control:
-
-```bash
-pretorin frameworks control nist-800-53-r5 ac-1
-```
-
-Include guidance and references:
-
-```bash
-pretorin frameworks control nist-800-53-r5 ac-1 --references
-```
-
-### Document Requirements
-
-Get document requirements for a framework:
-
-```bash
-pretorin frameworks documents fedramp-moderate
-```
-
-## CLI Commands
-
-### Authentication
-
-| Command | Description |
-|---------|-------------|
-| `pretorin login` | Authenticate with the Pretorin API |
-| `pretorin logout` | Clear stored credentials |
-| `pretorin whoami` | Display current authentication status |
-
-### Configuration
-
-| Command | Description |
-|---------|-------------|
-| `pretorin config list` | List all configuration |
-| `pretorin config get <key>` | Get a config value |
-| `pretorin config set <key> <value>` | Set a config value |
-| `pretorin config path` | Show config file path |
-
-### Frameworks
-
-| Command | Description |
-|---------|-------------|
-| `pretorin frameworks list` | List all compliance frameworks |
-| `pretorin frameworks get <id>` | Get framework details |
-| `pretorin frameworks families <id>` | List control families |
-| `pretorin frameworks controls <id>` | List controls |
-| `pretorin frameworks control <framework> <control>` | Get control details |
-| `pretorin frameworks documents <id>` | Get document requirements |
-
-### Utilities
-
-| Command | Description |
-|---------|-------------|
-| `pretorin version` | Show CLI version |
-| `pretorin update` | Update to latest version |
-| `pretorin mcp-serve` | Start the MCP server |
-
-## MCP Server
+## MCP Integration
 
 <img src="Rome-bot_Basic-1.png" alt="Rome-bot" width="120" align="right">
 
-The Pretorin CLI includes an MCP (Model Context Protocol) server that enables AI assistants like Claude to access compliance framework data directly during conversations.
+The Pretorin CLI includes an MCP (Model Context Protocol) server that enables AI assistants to access compliance framework data directly during conversations.
 
 **Why MCP?**
 
-- **Real-time data** - Query the latest compliance frameworks and controls
-- **Reduce hallucination** - Work with authoritative compliance data
-- **Streamline workflows** - No copy-pasting between tools
+- **Real-time data** — Query the latest compliance frameworks and controls
+- **Reduce hallucination** — Work with authoritative compliance data instead of training knowledge
+- **Streamline workflows** — No copy-pasting between tools
 
-### Quick Setup
+### Setup
 
-1. **Install and authenticate:**
-   ```bash
-   pip install pretorin
-   pretorin login
-   ```
+Install and authenticate first:
 
-2. **Add to Claude Desktop config:**
+```bash
+pip install pretorin
+pretorin login
+```
 
-   **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+Then add Pretorin to your AI tool of choice:
 
-   **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+<details>
+<summary><strong>Claude Desktop</strong></summary>
 
-   **Linux**: `~/.config/Claude/claude_desktop_config.json`
+Add to your Claude Desktop configuration file:
 
-   ```json
-   {
-     "mcpServers": {
-       "pretorin": {
-         "command": "pretorin",
-         "args": ["mcp-serve"]
-       }
-     }
-   }
-   ```
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+**Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-3. **Restart Claude Desktop**
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving.
+
+</details>
+
+<details>
+<summary><strong>Claude Code</strong></summary>
+
+Add a `.mcp.json` file to your project root:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "type": "stdio",
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Claude Code will detect the file automatically.
+
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Restart Cursor after saving.
+
+</details>
+
+<details>
+<summary><strong>OpenAI Codex CLI</strong></summary>
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pretorin]
+command = "pretorin"
+args = ["mcp-serve"]
+```
+
+</details>
+
+<details>
+<summary><strong>Windsurf</strong></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Restart Windsurf after saving.
+
+</details>
 
 ### Available Tools
 
@@ -225,14 +209,52 @@ The Pretorin CLI includes an MCP (Model Context Protocol) server that enables AI
 
 ### Example Prompts
 
-Try asking Claude:
+Try asking your AI assistant:
 
 - "What compliance frameworks are available for government systems?"
-- "Explain AC-2 (Account Management) requirements for FedRAMP Moderate"
+- "What are the Account Management requirements for FedRAMP Moderate?"
 - "What documents do I need for NIST 800-171 compliance?"
 - "Show me all Audit controls in NIST 800-53"
 
 For comprehensive MCP documentation, see [docs/MCP.md](docs/MCP.md).
+
+## CLI Reference
+
+### Authentication
+
+| Command | Description |
+|---------|-------------|
+| `pretorin login` | Authenticate with the Pretorin API |
+| `pretorin logout` | Clear stored credentials |
+| `pretorin whoami` | Display current authentication status |
+
+### Frameworks
+
+| Command | Description |
+|---------|-------------|
+| `pretorin frameworks list` | List all compliance frameworks |
+| `pretorin frameworks get <id>` | Get framework details |
+| `pretorin frameworks families <id>` | List control families |
+| `pretorin frameworks controls <id>` | List controls (use `--family` to filter) |
+| `pretorin frameworks control <framework> <control>` | Get control details (use `--references` for guidance) |
+| `pretorin frameworks documents <id>` | Get document requirements |
+
+### Configuration
+
+| Command | Description |
+|---------|-------------|
+| `pretorin config list` | List all configuration |
+| `pretorin config get <key>` | Get a config value |
+| `pretorin config set <key> <value>` | Set a config value |
+| `pretorin config path` | Show config file path |
+
+### Utilities
+
+| Command | Description |
+|---------|-------------|
+| `pretorin version` | Show CLI version |
+| `pretorin update` | Update to latest version |
+| `pretorin mcp-serve` | Start the MCP server |
 
 ## Configuration
 
@@ -254,7 +276,7 @@ The initial public release includes these Government Core frameworks:
 - FedRAMP (Low, Moderate, High)
 - CMMC Level 1, 2, and 3
 
-Additional frameworks are available on the platform. See [docs.pretorin.com](https://docs.pretorin.com) for the full list.
+Additional frameworks are available on the platform. See [platform.pretorin.com/api/docs](https://platform.pretorin.com/api/docs) for the full list.
 
 ## Development
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -25,7 +25,10 @@ pip install pretorin
 pretorin login
 ```
 
-### 3. Configure Claude Desktop
+### 3. Configure Your AI Tool
+
+<details open>
+<summary><strong>Claude Desktop</strong></summary>
 
 Add to your Claude Desktop configuration file:
 
@@ -46,9 +49,87 @@ Add to your Claude Desktop configuration file:
 }
 ```
 
-### 4. Restart Claude Desktop
+Restart Claude Desktop after saving.
 
-Restart the Claude Desktop application to load the new MCP server.
+</details>
+
+<details>
+<summary><strong>Claude Code</strong></summary>
+
+Add a `.mcp.json` file to your project root:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "type": "stdio",
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Claude Code will detect the file automatically.
+
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Restart Cursor after saving.
+
+</details>
+
+<details>
+<summary><strong>OpenAI Codex CLI</strong></summary>
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pretorin]
+command = "pretorin"
+args = ["mcp-serve"]
+```
+
+</details>
+
+<details>
+<summary><strong>Windsurf</strong></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Restart Windsurf after saving.
+
+</details>
+
+### 4. Restart Your AI Tool
+
+Restart the application to load the new MCP server.
 
 ## Available Tools
 
@@ -58,7 +139,7 @@ The MCP server provides 7 tools for accessing compliance data:
 |------|-------------|
 | `pretorin_list_frameworks` | List all available compliance frameworks |
 | `pretorin_get_framework` | Get detailed metadata about a specific framework |
-| `pretorin_list_control_families` | List control families for a framework (AC, AU, CM, etc.) |
+| `pretorin_list_control_families` | List control families for a framework |
 | `pretorin_list_controls` | List controls, optionally filtered by family |
 | `pretorin_get_control` | Get detailed control information including parameters |
 | `pretorin_get_control_references` | Get control guidance, objectives, and related controls |
@@ -110,11 +191,11 @@ List controls for a framework, optionally filtered by family.
 
 **Parameters:**
 - `framework_id` (required): The framework ID
-- `family_id` (optional): Filter by control family ID (e.g., `ac`, `au`)
+- `family_id` (optional): Filter by control family ID (use `pretorin frameworks families <id>` to discover valid family IDs)
 
 **Returns:** List of controls with ID, title, and family.
 
-**Example prompt:** "Show me all Access Control (AC) controls in NIST 800-53"
+**Example prompt:** "Show me all Access Control controls in NIST 800-53"
 
 ---
 
@@ -124,11 +205,11 @@ Get detailed information about a specific control.
 
 **Parameters:**
 - `framework_id` (required): The framework ID
-- `control_id` (required): The control ID (e.g., `ac-1`, `au-2`)
+- `control_id` (required): The control ID (use `pretorin frameworks controls <id>` to discover valid control IDs)
 
 **Returns:** Control details including parameters, parts, and enhancement count.
 
-**Example prompt:** "Explain control AC-2 from NIST 800-53"
+**Example prompt:** "Explain the Account Management control from NIST 800-53"
 
 ---
 
@@ -142,7 +223,7 @@ Get reference information for a control including guidance and related controls.
 
 **Returns:** Statement, guidance, objectives, parameters, and related controls.
 
-**Example prompt:** "What is the guidance for implementing AC-2?"
+**Example prompt:** "What is the guidance for implementing Account Management?"
 
 ---
 
@@ -177,9 +258,9 @@ The MCP server also exposes resources for analysis guidance:
 
 ### Understanding a Control
 
-> **You:** I need to implement AC-2 (Account Management) for our FedRAMP Moderate system. What does it require?
+> **You:** I need to implement Account Management for our FedRAMP Moderate system. What does it require?
 >
-> **Claude:** *Uses pretorin_get_control and pretorin_get_control_references* AC-2 requires organizations to manage system accounts including identifying account types, establishing conditions for membership, and specifying authorized users...
+> **Claude:** *Uses pretorin_get_control and pretorin_get_control_references* Account Management requires organizations to manage system accounts including identifying account types, establishing conditions for membership, and specifying authorized users...
 
 ### Planning Documentation
 
@@ -191,7 +272,7 @@ The MCP server also exposes resources for analysis guidance:
 
 > **You:** Give me an overview of the Audit controls in NIST 800-53
 >
-> **Claude:** *Uses pretorin_list_controls with family filter* The Audit and Accountability (AU) family contains controls for audit events, content, storage, review, and reporting...
+> **Claude:** *Uses pretorin_list_controls with family filter* The Audit and Accountability family contains controls for audit events, content, storage, review, and reporting...
 
 ## Troubleshooting
 
@@ -247,7 +328,6 @@ pretorin whoami
 
 - Verify the framework ID exists: `pretorin frameworks list`
 - Verify the control ID exists: `pretorin frameworks controls <framework_id>`
-- Control IDs are case-insensitive (both `AC-1` and `ac-1` work)
 
 ## Using with Other MCP Clients
 
@@ -263,6 +343,6 @@ The server accepts JSON-RPC messages on stdin and responds on stdout.
 
 ## Support
 
-- Documentation: [docs.pretorin.com](https://docs.pretorin.com)
+- Documentation: [platform.pretorin.com/api/docs](https://platform.pretorin.com/api/docs)
 - Issues: [github.com/pretorin-ai/pretorin-cli/issues](https://github.com/pretorin-ai/pretorin-cli/issues)
 - Platform: [platform.pretorin.com](https://platform.pretorin.com)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ pretorin = "pretorin.cli.main:app"
 
 [project.urls]
 Homepage = "https://pretorin.com"
-Documentation = "https://docs.pretorin.com"
+Documentation = "https://platform.pretorin.com/api/docs"
 Repository = "https://github.com/pretorin-ai/pretorin-cli"
 Changelog = "https://github.com/pretorin-ai/pretorin-cli/blob/main/CHANGELOG.md"
 Issues = "https://github.com/pretorin-ai/pretorin-cli/issues"

--- a/src/pretorin/cli/auth.py
+++ b/src/pretorin/cli/auth.py
@@ -33,14 +33,12 @@ def login(
 ) -> None:
     """Authenticate with the Pretorin API.
 
-    Get your API key from the Pretorin platform at https://platform.pretorin.com/settings/developer
+    Get your API key from the Pretorin platform at https://platform.pretorin.com/
     """
     if api_key is None:
         rprint("\n[bold #FF9010]Welcome to Pretorin[/bold #FF9010]")
         rprint("[dim]Making compliance the best part of your day.[/dim]\n")
-        rprint(
-            "Get your API key from: [link=https://platform.pretorin.com/settings/developer]https://platform.pretorin.com/settings/developer[/link]\n"
-        )
+        rprint("Get your API key from: [link=https://platform.pretorin.com/]https://platform.pretorin.com/[/link]\n")
         api_key = typer.prompt("Enter your API key", hide_input=True)
 
     if not api_key:

--- a/src/pretorin/cli/commands.py
+++ b/src/pretorin/cli/commands.py
@@ -190,7 +190,7 @@ def framework_families(
 @app.command("controls")
 def framework_controls(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
-    family_id: str | None = typer.Option(None, "--family", "-f", help="Filter by control family ID (e.g., ac, au)"),
+    family_id: str | None = typer.Option(None, "--family", "-f", help="Filter by control family ID"),
     limit: int = typer.Option(50, "--limit", "-n", help="Maximum number of controls to show"),
 ) -> None:
     """List controls for a framework."""
@@ -252,7 +252,7 @@ def framework_controls(
 @app.command("control")
 def control_get(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
-    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-1, ac-2)"),
+    control_id: str = typer.Argument(..., help="Control ID"),
     references: bool = typer.Option(False, "--references", "-r", help="Include guidance and references"),
 ) -> None:
     """Get details of a specific control."""

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -226,7 +226,7 @@ class PretorianClient:
 
         Args:
             framework_id: ID of the framework.
-            family_id: ID of the control family (e.g., ac, au, cm).
+            family_id: ID of the control family.
 
         Returns:
             ControlFamilyDetail with family info and controls list.
@@ -264,7 +264,7 @@ class PretorianClient:
 
         Args:
             framework_id: ID of the framework.
-            control_id: ID of the control (e.g., ac-1, ac-2).
+            control_id: ID of the control.
 
         Returns:
             ControlDetail with full control information.

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -160,7 +160,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="pretorin_list_control_families",
-            description="List all control families for a specific framework (e.g., AC, AU, CM for NIST)",
+            description="List all control families for a specific framework",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -184,7 +184,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "family_id": {
                         "type": "string",
-                        "description": "Optional: Filter by control family ID (e.g., ac, au, cm)",
+                        "description": "Optional: Filter by control family ID",
                     },
                 },
                 "required": ["framework_id"],
@@ -202,7 +202,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "control_id": {
                         "type": "string",
-                        "description": "The control ID (e.g., ac-1, ac-2, au-2)",
+                        "description": "The control ID",
                     },
                 },
                 "required": ["framework_id", "control_id"],
@@ -220,7 +220,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "control_id": {
                         "type": "string",
-                        "description": "The control ID (e.g., ac-1, ac-2)",
+                        "description": "The control ID",
                     },
                 },
                 "required": ["framework_id", "control_id"],


### PR DESCRIPTION
## Summary

- **Fix broken URLs** across 6 files: `docs.pretorin.com` → `platform.pretorin.com/api/docs`, `platform.pretorin.com/settings/developer` → `platform.pretorin.com/`
- **Restructure README** to lead with MCP integration as the hero section, with collapsible setup instructions for 5 AI tools (Claude Desktop, Claude Code, Cursor, OpenAI Codex CLI, Windsurf)
- **Remove incorrect example IDs** (`ac`, `au`, `ac-1`, `ac-2`) from CLI help text, API docstrings, and MCP tool descriptions — the API uses slug-style IDs discovered via `pretorin frameworks families/controls`
- **Remove false claim** about case-insensitive control IDs from MCP docs
- **Add multi-tool MCP setup** to `docs/MCP.md` matching the README

## Test plan

- [x] `ruff check src/pretorin` passes
- [x] `ruff format --check src/pretorin` passes
- [x] `pytest` — 101 passed, 27 skipped (integration tests)
- [ ] Verify README renders correctly on GitHub (collapsible sections, tables)
- [ ] Verify docs/MCP.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)