### PR TITLE
feat: CLI improvements and --json output for v0.2.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pretorin": {
+      "command": "pretorin",
+      "args": ["mcp-serve"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-06
+
+### Added
+- `--json` flag for machine-readable output across all commands (for scripting and AI agents)
+- `pretorin frameworks family <framework> <family>` command to get control family details
+- `pretorin frameworks metadata <framework>` command to get control metadata for a framework
+- `pretorin frameworks submit-artifact <file>` command to submit compliance artifacts
+- Positional `FAMILY_ID` argument on `controls` command (`pretorin frameworks controls fedramp-low access-control`)
+- Full AI Guidance content rendering on control detail view
+- `.mcp.json` for Claude Code MCP auto-discovery
+- Usage examples in all command docstrings and error messages
+
+### Changed
+- Control references (statement, guidance, objectives) now shown by default on `control` command
+- `--references/-r` flag replaced by `--brief/-b` to skip references (old flag kept as hidden deprecated no-op)
+- Default controls limit changed from 50 to 0 (show all) to prevent truncated results
+- Improved error messages with example command syntax
+
 ## [0.1.0] - 2025-02-03
 
 ### Added
@@ -48,5 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMMC Level 1, 2, and 3
 - Additional frameworks available on the platform
 
-[Unreleased]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/pretorin-ai/pretorin-cli/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.1.0"
+version = "0.2.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/pretorin/cli/commands.py
+++ b/src/pretorin/cli/commands.py
@@ -1,6 +1,9 @@
 """Framework commands for Pretorin CLI."""
 
 import asyncio
+import json
+from pathlib import Path
+from typing import Any
 
 import typer
 from rich import print as rprint
@@ -9,8 +12,10 @@ from rich.panel import Panel
 from rich.table import Table
 
 from pretorin.cli.animations import AnimationTheme, animated_status
+from pretorin.cli.output import is_json_mode, print_json
 from pretorin.client import PretorianClient
 from pretorin.client.api import AuthenticationError, NotFoundError, PretorianClientError
+from pretorin.client.models import ComplianceArtifact
 
 app = typer.Typer()
 console = Console()
@@ -31,13 +36,23 @@ def require_auth(client: PretorianClient) -> None:
 
 @app.command("list")
 def frameworks_list() -> None:
-    """List all available compliance frameworks."""
+    """List all available compliance frameworks.
+
+    Examples:
+        pretorin frameworks list
+        pretorin --json frameworks list
+    """
 
     async def fetch_frameworks() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    result = await client.list_frameworks()
+                    print_json(result)
+                    return
+
                 with animated_status("Consulting the compliance archives...", AnimationTheme.SEARCHING):
                     result = await client.list_frameworks()
 
@@ -92,13 +107,24 @@ def frameworks_list() -> None:
 def framework_get(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
 ) -> None:
-    """Get details of a specific framework."""
+    """Get details of a specific framework.
+
+    Examples:
+        pretorin frameworks get nist-800-53-r5
+        pretorin frameworks get fedramp-moderate
+        pretorin --json frameworks get nist-800-53-r5
+    """
 
     async def fetch_framework() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    framework = await client.get_framework(framework_id)
+                    print_json(framework)
+                    return
+
                 with animated_status("Gathering framework details...", AnimationTheme.MARCHING):
                     framework = await client.get_framework(framework_id)
 
@@ -121,6 +147,7 @@ def framework_get(
             except NotFoundError:
                 rprint(f"[#EAB536][°︵°][/#EAB536] Couldn't find framework: {framework_id}")
                 rprint("[dim]Try [bold]pretorin frameworks list[/bold] to see what's available.[/dim]")
+                rprint("[dim]Example: [bold]pretorin frameworks get fedramp-moderate[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
@@ -137,13 +164,24 @@ def framework_get(
 def framework_families(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
 ) -> None:
-    """List control families for a framework."""
+    """List control families for a framework.
+
+    Examples:
+        pretorin frameworks families nist-800-53-r5
+        pretorin frameworks families fedramp-low
+        pretorin --json frameworks families fedramp-moderate
+    """
 
     async def fetch_families() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    families = await client.list_control_families(framework_id)
+                    print_json(families)
+                    return
+
                 with animated_status("Gathering control families...", AnimationTheme.MARCHING):
                     families = await client.list_control_families(framework_id)
 
@@ -175,6 +213,7 @@ def framework_families(
             except NotFoundError:
                 rprint(f"[#EAB536][°︵°][/#EAB536] Couldn't find framework: {framework_id}")
                 rprint("[dim]Try [bold]pretorin frameworks list[/bold] to see what's available.[/dim]")
+                rprint("[dim]Example: [bold]pretorin frameworks families fedramp-moderate[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
@@ -190,16 +229,37 @@ def framework_families(
 @app.command("controls")
 def framework_controls(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
-    family_id: str | None = typer.Option(None, "--family", "-f", help="Filter by control family ID"),
-    limit: int = typer.Option(50, "--limit", "-n", help="Maximum number of controls to show"),
+    family_id_arg: str | None = typer.Argument(
+        None, help="Filter by control family ID (e.g., access-control)", metavar="FAMILY_ID"
+    ),
+    family_id_opt: str | None = typer.Option(None, "--family", "-f", help="Filter by control family ID"),
+    limit: int = typer.Option(0, "--limit", "-n", help="Maximum number of controls to show (0 = all)"),
 ) -> None:
-    """List controls for a framework."""
+    """List controls for a framework.
+
+    The family filter can be passed as a positional argument or with --family/-f.
+
+    Examples:
+        pretorin frameworks controls fedramp-low
+        pretorin frameworks controls fedramp-low access-control
+        pretorin frameworks controls fedramp-low -f access-control
+        pretorin frameworks controls nist-800-53-r5 --limit 20
+        pretorin --json frameworks controls fedramp-moderate
+    """
+    family_id = family_id_arg or family_id_opt
 
     async def fetch_controls() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    controls = await client.list_controls(framework_id, family_id)
+                    if limit > 0:
+                        controls = controls[:limit]
+                    print_json(controls)
+                    return
+
                 with animated_status("Searching for controls...", AnimationTheme.SEARCHING):
                     controls = await client.list_controls(framework_id, family_id)
 
@@ -207,9 +267,8 @@ def framework_controls(
                     rprint("[dim]No controls found for this selection.[/dim]")
                     return
 
-                # Apply limit
-                display_controls = controls[:limit]
                 total = len(controls)
+                display_controls = controls[:limit] if limit > 0 else controls
 
                 table = Table(
                     title=f"Controls - {framework_id}" + (f" (Family: {family_id})" if family_id else ""),
@@ -229,14 +288,15 @@ def framework_controls(
 
                 console.print(table)
 
-                if total > limit:
-                    rprint(f"\n[dim]Showing {limit} of {total} controls. Use --limit to see more.[/dim]")
+                if limit > 0 and total > limit:
+                    rprint(f"\n[dim]Showing {limit} of {total} controls. Use --limit 0 to see all.[/dim]")
                 else:
                     rprint(f"\n[dim]Total: {total} control(s)[/dim]")
 
             except NotFoundError:
                 rprint(f"[#EAB536][°︵°][/#EAB536] Couldn't find framework: {framework_id}")
                 rprint("[dim]Try [bold]pretorin frameworks list[/bold] to see what's available.[/dim]")
+                rprint("[dim]Example: [bold]pretorin frameworks controls fedramp-low access-control[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
@@ -252,21 +312,51 @@ def framework_controls(
 @app.command("control")
 def control_get(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
-    control_id: str = typer.Argument(..., help="Control ID"),
-    references: bool = typer.Option(False, "--references", "-r", help="Include guidance and references"),
+    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-2, ia-02)"),
+    brief: bool = typer.Option(
+        False,
+        "--brief",
+        "-b",
+        help="Show only basic control info (skip references and guidance)",
+    ),
+    _references: bool = typer.Option(
+        False,
+        "--references",
+        "-r",
+        hidden=True,
+        help="Deprecated: references are now shown by default",
+    ),
 ) -> None:
-    """Get details of a specific control."""
+    """Get details of a specific control.
+
+    By default, shows the full control including statement, guidance, AI guidance,
+    and references. Use --brief to show only the basic info panel.
+
+    Examples:
+        pretorin frameworks control fedramp-low ia-02
+        pretorin frameworks control nist-800-53-r5 ac-2
+        pretorin frameworks control fedramp-low ia-02 --brief
+        pretorin --json frameworks control fedramp-moderate ac-2
+    """
 
     async def fetch_control() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    control = await client.get_control(framework_id, control_id)
+                    refs = await client.get_control_references(framework_id, control_id) if not brief else None
+                    data: dict[str, Any] = control.model_dump(mode="json")
+                    if refs:
+                        data["references"] = refs.model_dump(mode="json")
+                    print_json(data)
+                    return
+
                 with animated_status("Looking up control details...", AnimationTheme.SEARCHING):
                     control = await client.get_control(framework_id, control_id)
-
                     refs = None
-                    if references:
+                    if not brief:
                         refs = await client.get_control_references(framework_id, control_id)
 
                 # Build control info
@@ -277,9 +367,6 @@ def control_get(
                     f"[bold]Type:[/bold] {control.control_type or '-'}",
                 ]
 
-                if control.ai_guidance:
-                    info_lines.append("\n[bold]AI Guidance:[/bold] Available")
-
                 rprint(
                     Panel(
                         "\n".join(info_lines),
@@ -288,7 +375,7 @@ def control_get(
                     )
                 )
 
-                # Show references if requested
+                # Show references (now default unless --brief)
                 if refs:
                     if refs.statement:
                         rprint("\n[bold]Statement:[/bold]")
@@ -310,6 +397,11 @@ def control_get(
                         related = ", ".join(rc.id.upper() for rc in refs.related_controls[:10])
                         rprint(f"  {related}")
 
+                # Show AI Guidance content if available
+                if not brief and control.ai_guidance:
+                    rprint("\n[bold #FF9010]AI Guidance:[/bold #FF9010]")
+                    _render_ai_guidance(control.ai_guidance)
+
                 # Show parameters if present
                 if control.params:
                     rprint("\n[bold]Parameters:[/bold]")
@@ -328,6 +420,7 @@ def control_get(
                     f"[dim]Try [bold]pretorin frameworks controls {framework_id}[/bold] "
                     "to see available controls.[/dim]"
                 )
+                rprint(f"[dim]Example: [bold]pretorin frameworks control {framework_id} ac-2[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
@@ -340,17 +433,45 @@ def control_get(
     asyncio.run(fetch_control())
 
 
+def _render_ai_guidance(guidance: dict[str, Any]) -> None:
+    """Render AI guidance content with appropriate formatting."""
+    for key, value in guidance.items():
+        heading = key.replace("_", " ").title()
+        if isinstance(value, str):
+            rprint(Panel(value, title=heading, border_style="#FF9010"))
+        elif isinstance(value, list):
+            rprint(f"\n  [bold]{heading}:[/bold]")
+            for i, item in enumerate(value, 1):
+                rprint(f"    {i}. {item}")
+        elif isinstance(value, dict):
+            rprint(f"\n  [bold]{heading}:[/bold]")
+            for k, v in value.items():
+                rprint(f"    [bold]{k}:[/bold] {v}")
+        else:
+            rprint(f"  [bold]{heading}:[/bold] {value}")
+
+
 @app.command("documents")
 def framework_documents(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
 ) -> None:
-    """Get document requirements for a framework."""
+    """Get document requirements for a framework.
+
+    Examples:
+        pretorin frameworks documents fedramp-moderate
+        pretorin --json frameworks documents fedramp-moderate
+    """
 
     async def fetch_documents() -> None:
         async with PretorianClient() as client:
             require_auth(client)
 
             try:
+                if is_json_mode():
+                    docs = await client.get_document_requirements(framework_id)
+                    print_json(docs)
+                    return
+
                 with animated_status("Gathering document requirements...", AnimationTheme.MARCHING):
                     docs = await client.get_document_requirements(framework_id)
 
@@ -385,6 +506,7 @@ def framework_documents(
                     "[dim]This framework may not have document requirements, "
                     "or check the ID with [bold]pretorin frameworks list[/bold].[/dim]"
                 )
+                rprint("[dim]Example: [bold]pretorin frameworks documents fedramp-moderate[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
@@ -395,3 +517,222 @@ def framework_documents(
                 raise typer.Exit(1)
 
     asyncio.run(fetch_documents())
+
+
+# =============================================================================
+# New Commands: family, metadata, submit-artifact
+# =============================================================================
+
+
+@app.command("family")
+def family_get(
+    framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
+    family_id: str = typer.Argument(..., help="Family ID (e.g., access-control)"),
+) -> None:
+    """Get details of a specific control family, including its controls.
+
+    Examples:
+        pretorin frameworks family fedramp-low access-control
+        pretorin frameworks family nist-800-53-r5 audit-and-accountability
+        pretorin --json frameworks family fedramp-moderate access-control
+    """
+
+    async def fetch_family() -> None:
+        async with PretorianClient() as client:
+            require_auth(client)
+
+            try:
+                if is_json_mode():
+                    family = await client.get_control_family(framework_id, family_id)
+                    print_json(family)
+                    return
+
+                with animated_status("Gathering family details...", AnimationTheme.MARCHING):
+                    family = await client.get_control_family(framework_id, family_id)
+
+                rprint(
+                    Panel(
+                        f"[bold]ID:[/bold] {family.id}\n"
+                        f"[bold]Title:[/bold] {family.title}\n"
+                        f"[bold]Class:[/bold] {family.class_type}\n"
+                        f"[bold]Controls:[/bold] {len(family.controls)}",
+                        title=f"Family: {family.title}",
+                        border_style="#EAB536",
+                    )
+                )
+
+                if family.controls:
+                    table = Table(
+                        title=f"Controls in {family.title}",
+                        show_header=True,
+                        header_style="bold",
+                    )
+                    table.add_column("ID", style="cyan")
+                    table.add_column("Title")
+                    table.add_column("Class")
+
+                    for ctrl in family.controls:
+                        table.add_row(
+                            ctrl.id,
+                            ctrl.title[:60] + "..." if len(ctrl.title) > 60 else ctrl.title,
+                            ctrl.class_type or "-",
+                        )
+
+                    console.print(table)
+
+            except NotFoundError:
+                rprint(f"[#EAB536][°︵°][/#EAB536] Couldn't find family [bold]{family_id}[/bold] in {framework_id}")
+                rprint(
+                    f"[dim]Try [bold]pretorin frameworks families {framework_id}[/bold] "
+                    "to see available families.[/dim]"
+                )
+                rprint(f"[dim]Example: [bold]pretorin frameworks family {framework_id} access-control[/bold][/dim]")
+                raise typer.Exit(1)
+            except AuthenticationError as e:
+                rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
+                rprint("[dim]Try running [bold]pretorin login[/bold] again.[/dim]")
+                raise typer.Exit(1)
+            except PretorianClientError as e:
+                rprint(f"[#FF9010]→[/#FF9010] {e.message}")
+                raise typer.Exit(1)
+
+    asyncio.run(fetch_family())
+
+
+@app.command("metadata")
+def framework_metadata(
+    framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
+) -> None:
+    """Get metadata for all controls in a framework.
+
+    Shows control ID, title, family, and type for every control in the framework.
+
+    Examples:
+        pretorin frameworks metadata fedramp-low
+        pretorin frameworks metadata nist-800-53-r5
+        pretorin --json frameworks metadata fedramp-moderate
+    """
+
+    async def fetch_metadata() -> None:
+        async with PretorianClient() as client:
+            require_auth(client)
+
+            try:
+                if is_json_mode():
+                    metadata = await client.get_controls_metadata(framework_id)
+                    print_json(metadata)
+                    return
+
+                with animated_status("Gathering control metadata...", AnimationTheme.SEARCHING):
+                    metadata = await client.get_controls_metadata(framework_id)
+
+                if not metadata:
+                    rprint("[dim]No control metadata found for this framework.[/dim]")
+                    return
+
+                table = Table(
+                    title=f"Control Metadata - {framework_id}",
+                    show_header=True,
+                    header_style="bold",
+                )
+                table.add_column("Control ID", style="cyan")
+                table.add_column("Title")
+                table.add_column("Family")
+                table.add_column("Type")
+
+                for control_id, meta in sorted(metadata.items()):
+                    table.add_row(
+                        control_id,
+                        meta.title[:60] + "..." if len(meta.title) > 60 else meta.title,
+                        meta.family.upper(),
+                        meta.type,
+                    )
+
+                console.print(table)
+                rprint(f"\n[dim]Total: {len(metadata)} control(s)[/dim]")
+
+            except NotFoundError:
+                rprint(f"[#EAB536][°︵°][/#EAB536] Couldn't find framework: {framework_id}")
+                rprint("[dim]Try [bold]pretorin frameworks list[/bold] to see what's available.[/dim]")
+                rprint("[dim]Example: [bold]pretorin frameworks metadata fedramp-low[/bold][/dim]")
+                raise typer.Exit(1)
+            except AuthenticationError as e:
+                rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
+                rprint("[dim]Try running [bold]pretorin login[/bold] again.[/dim]")
+                raise typer.Exit(1)
+            except PretorianClientError as e:
+                rprint(f"[#FF9010]→[/#FF9010] {e.message}")
+                raise typer.Exit(1)
+
+    asyncio.run(fetch_metadata())
+
+
+@app.command("submit-artifact")
+def submit_artifact(
+    file_path: Path = typer.Argument(
+        ...,
+        help="Path to a JSON file containing the compliance artifact",
+        exists=True,
+        readable=True,
+    ),
+) -> None:
+    """Submit a compliance artifact from a JSON file.
+
+    The JSON file should contain a ComplianceArtifact with framework_id, control_id,
+    component definition, and confidence level.
+
+    Examples:
+        pretorin frameworks submit-artifact artifact.json
+        pretorin --json frameworks submit-artifact artifact.json
+    """
+
+    try:
+        raw = json.loads(file_path.read_text())
+        artifact = ComplianceArtifact(**raw)
+    except json.JSONDecodeError as e:
+        rprint(f"[#EAB536][°︵°][/#EAB536] Invalid JSON in {file_path}: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        rprint(f"[#EAB536][°︵°][/#EAB536] Failed to parse artifact: {e}")
+        rprint("[dim]Ensure the file matches the ComplianceArtifact schema.[/dim]")
+        raise typer.Exit(1)
+
+    async def do_submit() -> None:
+        async with PretorianClient() as client:
+            require_auth(client)
+
+            try:
+                if is_json_mode():
+                    result = await client.submit_artifact(artifact)
+                    print_json(result)
+                    return
+
+                with animated_status("Submitting compliance artifact...", AnimationTheme.MARCHING):
+                    result = await client.submit_artifact(artifact)
+
+                artifact_id = result.get("artifact_id", "unknown")
+                url = result.get("url")
+
+                info = f"[bold]Artifact ID:[/bold] {artifact_id}"
+                if url:
+                    info += f"\n[bold]URL:[/bold] {url}"
+                info += f"\n[bold]Framework:[/bold] {artifact.framework_id}"
+                info += f"\n[bold]Control:[/bold] {artifact.control_id}"
+
+                rprint(
+                    Panel(
+                        info,
+                        title="[#95D7E0]Artifact Submitted[/#95D7E0]",
+                        border_style="#95D7E0",
+                    )
+                )
+
+            except AuthenticationError as e:
+                rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")
+                rprint("[dim]Try running [bold]pretorin login[/bold] again.[/dim]")
+                raise typer.Exit(1)
+            except PretorianClientError as e:
+                rprint(f"[#FF9010]→[/#FF9010] {e.message}")
+                raise typer.Exit(1)
+
+    asyncio.run(do_submit())

--- a/src/pretorin/cli/main.py
+++ b/src/pretorin/cli/main.py
@@ -1,5 +1,7 @@
 """Main CLI application setup for Pretorin."""
 
+import json
+
 import typer
 from rich import print as rprint
 from rich.console import Console
@@ -8,6 +10,7 @@ from pretorin import __version__
 from pretorin.cli.auth import app as auth_app
 from pretorin.cli.commands import app as frameworks_app
 from pretorin.cli.config import app as config_app
+from pretorin.cli.output import set_json_mode
 
 console = Console()
 
@@ -50,16 +53,25 @@ app = typer.Typer(
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(False, "--json", help="Output results as JSON (for scripting and AI agents)"),
+) -> None:
     """CLI for the Pretorin Compliance Platform.
 
     Making compliance the best part of your day.
     """
+    if json_output:
+        set_json_mode(True)
+
     # Show banner and help when no subcommand is provided
     if ctx.invoked_subcommand is None:
-        show_banner()
-        # Show the help text after the banner
-        rprint(ctx.get_help())
+        if json_output:
+            print(json.dumps({"version": __version__}))
+        else:
+            show_banner()
+            # Show the help text after the banner
+            rprint(ctx.get_help())
 
 
 # Add sub-command groups

--- a/src/pretorin/cli/output.py
+++ b/src/pretorin/cli/output.py
@@ -1,0 +1,41 @@
+"""JSON output mode helpers for Pretorin CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from pydantic import BaseModel
+
+_json_mode: bool = False
+
+
+def set_json_mode(enabled: bool) -> None:
+    """Enable or disable JSON output mode."""
+    global _json_mode
+    _json_mode = enabled
+
+
+def is_json_mode() -> bool:
+    """Check if JSON output mode is enabled."""
+    return _json_mode
+
+
+def print_json(data: Any) -> None:
+    """Print data as formatted JSON to stdout.
+
+    Handles Pydantic models, lists of models, and plain dicts/lists.
+    """
+    serialized: Any
+    if isinstance(data, BaseModel):
+        serialized = data.model_dump(mode="json")
+    elif isinstance(data, list):
+        serialized = [item.model_dump(mode="json") if isinstance(item, BaseModel) else item for item in data]
+    elif isinstance(data, dict):
+        serialized = {k: v.model_dump(mode="json") if isinstance(v, BaseModel) else v for k, v in data.items()}
+    else:
+        serialized = data
+
+    json.dump(serialized, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,96 @@
+"""Unit tests for the JSON output module."""
+
+import json
+
+from pydantic import BaseModel
+
+from pretorin.cli.output import is_json_mode, print_json, set_json_mode
+
+
+class SampleModel(BaseModel):
+    """Test model for print_json."""
+
+    name: str
+    value: int
+
+
+class TestJsonModeFlag:
+    """Tests for the JSON mode flag."""
+
+    def teardown_method(self) -> None:
+        set_json_mode(False)
+
+    def test_default_is_false(self) -> None:
+        set_json_mode(False)
+        assert is_json_mode() is False
+
+    def test_set_true(self) -> None:
+        set_json_mode(True)
+        assert is_json_mode() is True
+
+    def test_set_false(self) -> None:
+        set_json_mode(True)
+        set_json_mode(False)
+        assert is_json_mode() is False
+
+
+class TestPrintJson:
+    """Tests for print_json serialization."""
+
+    def test_dict(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        print_json({"key": "value", "count": 42})
+        captured = capsys_fixture.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"key": "value", "count": 42}
+
+    def test_pydantic_model(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        model = SampleModel(name="test", value=10)
+        print_json(model)
+        captured = capsys_fixture.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"name": "test", "value": 10}
+
+    def test_list_of_models(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        models = [SampleModel(name="a", value=1), SampleModel(name="b", value=2)]
+        print_json(models)
+        captured = capsys_fixture.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == 2
+        assert data[0]["name"] == "a"
+        assert data[1]["value"] == 2
+
+    def test_list_of_dicts(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        print_json([{"x": 1}, {"x": 2}])
+        captured = capsys_fixture.readouterr()
+        data = json.loads(captured.out)
+        assert data == [{"x": 1}, {"x": 2}]
+
+    def test_dict_with_model_values(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        print_json({"item": SampleModel(name="nested", value=99)})
+        captured = capsys_fixture.readouterr()
+        data = json.loads(captured.out)
+        assert data["item"] == {"name": "nested", "value": 99}
+
+    def test_output_is_valid_json(self, capsys: object) -> None:
+        import _pytest.capture
+
+        capsys_fixture: _pytest.capture.CaptureFixture[str] = capsys  # type: ignore[assignment]
+        print_json({"nested": {"a": [1, 2, 3]}})
+        captured = capsys_fixture.readouterr()
+        # Should not raise
+        json.loads(captured.out)


### PR DESCRIPTION
## Summary

- **`--json` flag** for machine-readable output across all commands (for scripting and AI agents)
- **3 new commands**: `frameworks family`, `frameworks metadata`, `frameworks submit-artifact`
- **Control references shown by default** (`--brief/-b` to skip, old `--references/-r` kept as hidden deprecated no-op)
- **AI Guidance content** now fully rendered instead of just "Available"
- **Positional family argument** on `controls` command (e.g., `pretorin frameworks controls fedramp-low access-control`)
- **Default limit changed from 50 to 0** (show all controls) to prevent truncated results
- **Improved error messages** with usage examples in docstrings and NotFoundError handlers
- **`.mcp.json`** for Claude Code MCP auto-discovery
- Version bumped to **0.2.0**

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes (no issues in 18 source files)
- [x] `pytest` passes (110 unit tests)
- [ ] CI lint, typecheck, test, docker-test jobs pass
- [ ] CI integration tests pass on master after merge
- [ ] After merge: create GitHub release `v0.2.0` to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)