### PR TITLE
fix: CLI bugs — version strings, MCP errors, auth consistency, control ID normalization

### DIFF
--- a/src/pretorin/cli/context.py
+++ b/src/pretorin/cli/context.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
+from pretorin.cli.commands import require_auth
 from pretorin.cli.output import is_json_mode, print_json
 
 console = Console()
@@ -61,9 +62,7 @@ async def _context_list() -> None:
     from pretorin.client.api import PretorianClient, PretorianClientError
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' or 'pretorin config set api-key <key>' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         if not is_json_mode():
             rprint(f"\n  {ROMEBOT_THINKING}  Fetching systems...\n")
@@ -195,9 +194,7 @@ async def _context_set(
     from pretorin.client.config import Config
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' or 'pretorin config set api-key <key>' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         if not is_json_mode():
             rprint(f"\n  {ROMEBOT_THINKING}  Connecting to Pretorin...\n")

--- a/src/pretorin/cli/evidence.py
+++ b/src/pretorin/cli/evidence.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from pretorin.cli.commands import require_auth
 from pretorin.cli.output import is_json_mode, print_json
 from pretorin.utils import normalize_control_id
 
@@ -188,9 +189,7 @@ async def _push_evidence(dry_run: bool) -> None:
     from pretorin.evidence.sync import EvidenceSync
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         sync = EvidenceSync()
 

--- a/src/pretorin/cli/monitoring.py
+++ b/src/pretorin/cli/monitoring.py
@@ -10,6 +10,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from pretorin import __version__
+from pretorin.cli.commands import require_auth
 from pretorin.cli.output import is_json_mode
 
 console = Console()
@@ -115,9 +117,7 @@ async def _push_event(
         raise typer.Exit(1)
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' or 'pretorin config set api-key <key>' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         # Resolve system
         if not is_json_mode():
@@ -186,7 +186,7 @@ async def _push_event(
             description=description,
             severity=severity,
             control_id=control,
-            event_data={"source": "pretorin-cli", "cli_version": "0.1.0"},
+            event_data={"source": "pretorin-cli", "cli_version": __version__},
         )
 
         try:

--- a/src/pretorin/cli/narrative.py
+++ b/src/pretorin/cli/narrative.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import typer
 from rich import print as rprint
 
+from pretorin.cli.commands import require_auth
 from pretorin.cli.output import is_json_mode, print_json
+from pretorin.utils import normalize_control_id
 
 app = typer.Typer(
     name="narrative",
@@ -42,6 +44,7 @@ def narrative_push(
         rprint("[red]File is empty.[/red]")
         raise typer.Exit(1)
 
+    control_id = normalize_control_id(control_id)
     asyncio.run(_push_narrative(control_id, framework_id, system, content))
 
 
@@ -55,9 +58,7 @@ async def _push_narrative(
     from pretorin.client.api import PretorianClient, PretorianClientError
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         # Resolve system
         try:

--- a/src/pretorin/cli/review.py
+++ b/src/pretorin/cli/review.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from pretorin.cli.commands import require_auth
 from pretorin.cli.context import resolve_context
 from pretorin.cli.output import is_json_mode, print_json
 
@@ -181,9 +182,7 @@ async def _run_review(
             raise typer.Exit(1)
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' or 'pretorin config set api-key <key>' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         # --- Fetch control details ---
         if not is_json_mode():
@@ -376,9 +375,7 @@ async def _review_status(
     )
 
     async with PretorianClient() as client:
-        if not client.is_configured:
-            rprint("[red]Not configured. Run 'pretorin login' or 'pretorin config set api-key <key>' first.[/red]")
-            raise typer.Exit(1)
+        require_auth(client)
 
         if not is_json_mode():
             rprint(f"\n  {ROMEBOT_WORKING}  Fetching implementation for {control_id.upper()}...\n")

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 
+from pretorin import __version__
 from pretorin.client.config import Config
 from pretorin.client.models import (
     ComplianceArtifact,
@@ -85,7 +86,7 @@ class PretorianClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": "pretorin-cli/0.1.0",
+            "User-Agent": f"pretorin-cli/{__version__}",
         }
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"

--- a/src/pretorin/mcp/analysis_prompts.py
+++ b/src/pretorin/mcp/analysis_prompts.py
@@ -795,7 +795,7 @@ No specific analysis guidance available for this control.
 2. Search the codebase for relevant implementations
 3. Document evidence with file paths and line numbers
 4. Assess implementation status based on findings
-5. Submit artifact using `pretorin_submit_artifact`
+5. Format your findings as a JSON artifact following the analysis schema
 
 ## Output Format
 
@@ -821,8 +821,8 @@ Use the schema from `analysis://schema` to format your artifact.
 Produce a JSON artifact following the schema from `analysis://schema`.
 Set the framework_id to `{framework_id}` and control_id to `{control_id}`.
 
-After analysis, validate with `pretorin_validate_artifact` and submit
-with `pretorin_submit_artifact`.
+Note: Artifact validation and submission are not yet available via MCP tools.
+Save the JSON artifact locally for manual review.
 """
 
 

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 from urllib.parse import urlparse
@@ -11,6 +12,7 @@ from urllib.parse import urlparse
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import (
+    CallToolResult,
     Resource,
     TextContent,
     Tool,
@@ -26,6 +28,8 @@ from pretorin.mcp.analysis_prompts import (
     get_framework_guide,
 )
 from pretorin.utils import normalize_control_id
+
+logger = logging.getLogger(__name__)
 
 ToolHandler = Callable[[PretorianClient, dict[str, Any]], Awaitable[list[TextContent]]]
 
@@ -45,9 +49,12 @@ server = Server(
 )
 
 
-def _format_error(message: str) -> list[TextContent]:
+def _format_error(message: str) -> CallToolResult:
     """Format an error message for MCP response."""
-    return [TextContent(type="text", text=f"Error: {message}")]
+    return CallToolResult(
+        content=[TextContent(type="text", text=f"Error: {message}")],
+        isError=True,
+    )
 
 
 def _format_json(data: Any) -> list[TextContent]:
@@ -177,7 +184,14 @@ async def read_resource(uri: str) -> str:
         # Support both analysis://control/ac-2 and analysis://control/fedramp-moderate/ac-2
         if len(path_parts) == 1:
             control_id = normalize_control_id(path_parts[0])
-            framework_id = "fedramp-moderate"  # Default framework
+            # Default to fedramp-moderate when no framework is specified in the URI
+            # (e.g. analysis://control/ac-2 vs analysis://control/fedramp-moderate/ac-2)
+            framework_id = "fedramp-moderate"
+            logger.warning(
+                "No framework specified in control resource URI 'analysis://control/%s', "
+                "defaulting to fedramp-moderate",
+                control_id,
+            )
         else:
             framework_id = path_parts[0]
             control_id = normalize_control_id(path_parts[1])

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -165,7 +165,8 @@ class TestEvidenceTools:
     def test_create_evidence_missing_system_id(self) -> None:
         client = _make_mock_client()
         result = _run_tool("pretorin_create_evidence", {"name": "New Evidence", "description": "Test"}, client)
-        assert any("Missing required" in c.text for c in result)
+        assert result.isError
+        assert any("Missing required" in c.text for c in result.content)
 
     def test_link_evidence(self) -> None:
         client = _make_mock_client(link_evidence_to_control={"linked": True})
@@ -180,7 +181,8 @@ class TestEvidenceTools:
     def test_link_evidence_missing_system_id(self) -> None:
         client = _make_mock_client()
         result = _run_tool("pretorin_link_evidence", {"evidence_id": "ev-1", "control_id": "ac-2"}, client)
-        assert any("Missing required" in c.text for c in result)
+        assert result.isError
+        assert any("Missing required" in c.text for c in result.content)
 
 
 class TestNarrativeTools:
@@ -278,7 +280,8 @@ class TestErrorHandling:
     def test_unknown_tool_returns_error(self) -> None:
         client = _make_mock_client()
         result = _run_tool("pretorin_nonexistent_tool", {}, client)
-        text = result[0].text
+        assert result.isError
+        text = result.content[0].text
         assert "Error" in text
         assert "Unknown tool" in text
 
@@ -286,7 +289,8 @@ class TestErrorHandling:
         client = AsyncMock()
         client.is_configured = False
         result = _run_tool("pretorin_list_systems", {}, client)
-        text = result[0].text
+        assert result.isError
+        text = result.content[0].text
         assert "Error" in text
         assert "Not authenticated" in text
 
@@ -294,7 +298,8 @@ class TestErrorHandling:
         client = _make_mock_client()
         client.get_system = AsyncMock(side_effect=NotFoundError("System not found", 404))
         result = _run_tool("pretorin_get_system", {"system_id": "bad-id"}, client)
-        text = result[0].text
+        assert result.isError
+        text = result.content[0].text
         assert "Error" in text
         assert "Not found" in text
 
@@ -302,6 +307,7 @@ class TestErrorHandling:
         client = _make_mock_client()
         client.list_systems = AsyncMock(side_effect=PretorianClientError("Server error", 500))
         result = _run_tool("pretorin_list_systems", {}, client)
-        text = result[0].text
+        assert result.isError
+        text = result.content[0].text
         assert "Error" in text
         assert "Server error" in text


### PR DESCRIPTION
Fixes 7 issues found during CLI QA testing:

1. User-Agent header and monitoring events were hardcoded to version 0.1.0 instead of using actual version
2. MCP analysis prompts referenced nonexistent tools (pretorin_validate_artifact, pretorin_submit_artifact)
3. MCP _format_error was not setting isError=True on CallToolResult, so clients couldn't distinguish errors from success
4. narrative push was not normalizing control IDs (ac-2 vs ac-02)
5. Auth checks were inlined with inconsistent error messages across 5 CLI modules — consolidated to use require_auth()
6. Hardcoded fedramp-moderate default in MCP server now logs a warning when used
7. All 194 tests pass