### PR TITLE
Fix MCP registry description length validation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -403,7 +403,7 @@ If you already use another AI agent, use the MCP mode instead (`pretorin mcp-ser
 
 ```bash
 # Free-form task
-pretorin agent run "Assess AC-2 implementation gaps for my system"
+pretorin agent run "Assess AC-02 implementation gaps for my system"
 
 # Use a predefined skill
 pretorin agent run --skill gap-analysis
@@ -452,7 +452,7 @@ pretorin agent doctor
 pretorin agent install
 
 # 4) Run a task
-pretorin agent run "Assess AC-2 implementation gaps for my system"
+pretorin agent run "Assess AC-02 implementation gaps for my system"
 ```
 
 Model key precedence for the agent runtime is:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -262,7 +262,7 @@ Get rich context for a control including AI guidance, control statement, assessm
 
 **Returns:** Combined control metadata and implementation details: AI guidance, statement, objectives, scope status, narrative, user context.
 
-**Example prompt:** "What's the full context for AC-2 in my FedRAMP Moderate system?"
+**Example prompt:** "What's the full context for AC-02 in my FedRAMP Moderate system?"
 
 ---
 
@@ -292,7 +292,7 @@ Push a narrative text update for a control implementation on the platform.
 
 **Returns:** Confirmation of the update.
 
-**Example prompt:** "Update the narrative for AC-2 with the implementation details I just described"
+**Example prompt:** "Update the narrative for AC-02 with the implementation details I just described"
 
 ## Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.5.3"
+version = "0.5.4"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.pretorin-ai/pretorin",
-  "description": "Access NIST 800-53, FedRAMP, CMMC, and NIST 800-171 compliance data. Manage systems, evidence, narratives, and monitoring from your AI tools.",
+  "description": "Access Pretorin compliance systems, controls, evidence, and narratives from your AI tools.",
   "title": "Pretorin Compliance",
   "websiteUrl": "https://pretorin.com",
   "repository": {

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/src/pretorin/agent/tools.py
+++ b/src/pretorin/agent/tools.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pretorin.client.api import PretorianClient
+from pretorin.utils import normalize_control_id
 
 
 @dataclass
@@ -56,6 +57,11 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         List of ToolDefinition instances.
     """
     tools: list[ToolDefinition] = []
+
+    def _normalize(control_id: str | None) -> str | None:
+        if control_id is None:
+            return None
+        return normalize_control_id(control_id)
 
     # --- Systems ---
 
@@ -122,7 +128,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
     )
 
     async def get_control(framework_id: str, control_id: str) -> str:
-        control = await client.get_control(framework_id, control_id)
+        control = await client.get_control(framework_id, _normalize(control_id) or control_id)
         return json.dumps(control.model_dump(), default=str)
 
     tools.append(
@@ -149,7 +155,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         limit: int = 20,
     ) -> str:
         evidence = await client.list_evidence(
-            control_id=control_id,
+            control_id=_normalize(control_id),
             framework_id=framework_id,
             limit=limit,
         )
@@ -186,7 +192,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
             description=description,
             evidence_type=evidence_type,
             source="agent",
-            control_id=control_id,
+            control_id=_normalize(control_id),
             framework_id=framework_id,
         )
         result = await client.create_evidence("", ev)
@@ -218,7 +224,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         control_id: str,
         framework_id: str | None = None,
     ) -> str:
-        narrative = await client.get_narrative(system_id, control_id, framework_id)
+        narrative = await client.get_narrative(system_id, _normalize(control_id) or control_id, framework_id)
         return json.dumps(narrative.model_dump(), default=str)
 
     tools.append(
@@ -255,7 +261,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
             title=title,
             description=description,
             severity=severity,
-            control_id=control_id,
+            control_id=_normalize(control_id),
             event_data={"source": "agent"},
         )
         result = await client.create_monitoring_event(system_id, event)
@@ -289,7 +295,12 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         status: str,
         framework_id: str | None = None,
     ) -> str:
-        result = await client.update_control_status(system_id, control_id, status, framework_id)
+        result = await client.update_control_status(
+            system_id,
+            _normalize(control_id) or control_id,
+            status,
+            framework_id,
+        )
         return json.dumps(result, default=str)
 
     tools.append(
@@ -315,7 +326,11 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         control_id: str,
         framework_id: str | None = None,
     ) -> str:
-        impl = await client.get_control_implementation(system_id, control_id, framework_id)
+        impl = await client.get_control_implementation(
+            system_id,
+            _normalize(control_id) or control_id,
+            framework_id,
+        )
         return json.dumps(impl.model_dump(), default=str)
 
     tools.append(
@@ -342,7 +357,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
         control_id: str,
         framework_id: str,
     ) -> str:
-        ctx = await client.get_control_context(system_id, control_id, framework_id)
+        ctx = await client.get_control_context(system_id, _normalize(control_id) or control_id, framework_id)
         return json.dumps(ctx.model_dump(), default=str)
 
     tools.append(
@@ -394,7 +409,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
     ) -> str:
         result = await client.update_narrative(
             system_id,
-            control_id,
+            _normalize(control_id) or control_id,
             narrative,
             framework_id,
             is_ai_generated,

--- a/src/pretorin/cli/commands.py
+++ b/src/pretorin/cli/commands.py
@@ -312,7 +312,7 @@ def framework_controls(
 @app.command("control")
 def control_get(
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., nist-800-53-r5)"),
-    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-2, ia-02)"),
+    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-02, ia-02)"),
     brief: bool = typer.Option(
         False,
         "--brief",
@@ -334,9 +334,9 @@ def control_get(
 
     Examples:
         pretorin frameworks control fedramp-low ia-02
-        pretorin frameworks control nist-800-53-r5 ac-2
+        pretorin frameworks control nist-800-53-r5 ac-02
         pretorin frameworks control fedramp-low ia-02 --brief
-        pretorin --json frameworks control fedramp-moderate ac-2
+        pretorin --json frameworks control fedramp-moderate ac-02
     """
 
     async def fetch_control() -> None:
@@ -420,7 +420,7 @@ def control_get(
                     f"[dim]Try [bold]pretorin frameworks controls {framework_id}[/bold] "
                     "to see available controls.[/dim]"
                 )
-                rprint(f"[dim]Example: [bold]pretorin frameworks control {framework_id} ac-2[/bold][/dim]")
+                rprint(f"[dim]Example: [bold]pretorin frameworks control {framework_id} ac-02[/bold][/dim]")
                 raise typer.Exit(1)
             except AuthenticationError as e:
                 rprint(f"[#FF9010]→[/#FF9010] Authentication issue: {e.message}")

--- a/src/pretorin/cli/evidence.py
+++ b/src/pretorin/cli/evidence.py
@@ -26,7 +26,7 @@ ROMEBOT_EVIDENCE = "[#EAB536]\\[°□°][/#EAB536]"
 
 @app.command("create")
 def evidence_create(
-    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-2)"),
+    control_id: str = typer.Argument(..., help="Control ID (e.g., ac-02)"),
     framework_id: str = typer.Argument(..., help="Framework ID (e.g., fedramp-moderate)"),
     description: str = typer.Option(
         ...,
@@ -57,8 +57,8 @@ def evidence_create(
     with YAML frontmatter for tracking.
 
     Examples:
-        pretorin evidence create ac-2 fedramp-moderate -d "RBAC configuration in Kubernetes"
-        pretorin evidence create sc-7 nist-800-53-r5 -d "Firewall rules" -t configuration
+        pretorin evidence create ac-02 fedramp-moderate -d "RBAC configuration in Kubernetes"
+        pretorin evidence create sc-07 nist-800-53-r5 -d "Firewall rules" -t configuration
     """
     from pretorin.evidence.writer import EvidenceWriter, LocalEvidence
 
@@ -141,7 +141,7 @@ def evidence_list(
     if not items:
         rprint("[dim]No local evidence found.[/dim]")
         rprint(
-            '[dim]Create one with: [bold]pretorin evidence create ac-2 fedramp-moderate -d "description"[/bold][/dim]'
+            '[dim]Create one with: [bold]pretorin evidence create ac-02 fedramp-moderate -d "description"[/bold][/dim]'
         )
         return
 

--- a/src/pretorin/cli/monitoring.py
+++ b/src/pretorin/cli/monitoring.py
@@ -57,7 +57,7 @@ def push(
         None,
         "--control",
         "-c",
-        help="Control ID (e.g., sc-7, ac-2).",
+        help="Control ID (e.g., sc-07, ac-02).",
     ),
     description: str = typer.Option(
         "",

--- a/src/pretorin/cli/narrative.py
+++ b/src/pretorin/cli/narrative.py
@@ -35,7 +35,7 @@ def narrative_push(
         pretorin agent run --skill narrative-generation "Generate narrative for AC-02"
 
     Examples:
-        pretorin narrative push ac-2 fedramp-moderate "My System" narrative-ac2.md
+        pretorin narrative push ac-02 fedramp-moderate "My System" narrative-ac2.md
     """
     content = file.read_text().strip()
     if not content:

--- a/src/pretorin/cli/review.py
+++ b/src/pretorin/cli/review.py
@@ -86,7 +86,7 @@ def run(
         ...,
         "--control-id",
         "-c",
-        help="Control ID to review against (e.g., ac-2, sc-7).",
+        help="Control ID to review against (e.g., ac-02, sc-07).",
     ),
     framework_id: str | None = typer.Option(
         None,
@@ -125,9 +125,9 @@ def run(
     as markdown files without requiring a system.
 
     Examples:
-        pretorin review run -c ac-2
-        pretorin review run -c sc-7 -f fedramp-moderate --path ./src
-        pretorin review run -c ac-2 --local -o ./compliance-notes
+        pretorin review run -c ac-02
+        pretorin review run -c sc-07 -f fedramp-moderate --path ./src
+        pretorin review run -c ac-02 --local -o ./compliance-notes
     """
     asyncio.run(
         _run_review(
@@ -332,7 +332,7 @@ def status(
         ...,
         "--control-id",
         "-c",
-        help="Control ID (e.g., ac-2, sc-7).",
+        help="Control ID (e.g., ac-02, sc-07).",
     ),
     system: str | None = typer.Option(
         None,
@@ -350,8 +350,8 @@ def status(
     """Show the implementation status for a specific control.
 
     Examples:
-        pretorin review status -c ac-2
-        pretorin review status -c sc-7 -f fedramp-moderate -s my-system
+        pretorin review status -c ac-02
+        pretorin review status -c sc-07 -f fedramp-moderate -s my-system
     """
     asyncio.run(
         _review_status(

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -27,6 +27,7 @@ from pretorin.client.models import (
     ScopeResponse,
     SystemDetail,
 )
+from pretorin.utils import normalize_control_id
 
 
 class PretorianClientError(Exception):
@@ -181,6 +182,13 @@ class PretorianClient:
 
         return response.json()
 
+    @staticmethod
+    def _normalize_control_id(control_id: str | None) -> str | None:
+        """Normalize control IDs where applicable (NIST/FedRAMP formats)."""
+        if control_id is None:
+            return None
+        return normalize_control_id(control_id)
+
     # =========================================================================
     # Auth / Validation
     # =========================================================================
@@ -290,7 +298,8 @@ class PretorianClient:
         Returns:
             ControlDetail with full control information.
         """
-        data = await self._request("GET", f"/frameworks/{framework_id}/controls/{control_id}")
+        normalized_control_id = self._normalize_control_id(control_id)
+        data = await self._request("GET", f"/frameworks/{framework_id}/controls/{normalized_control_id}")
         return ControlDetail(**data)
 
     async def get_control_references(self, framework_id: str, control_id: str) -> ControlReferences:
@@ -303,7 +312,11 @@ class PretorianClient:
         Returns:
             ControlReferences with statement, guidance, objectives, etc.
         """
-        data = await self._request("GET", f"/frameworks/{framework_id}/controls/{control_id}/references")
+        normalized_control_id = self._normalize_control_id(control_id)
+        data = await self._request(
+            "GET",
+            f"/frameworks/{framework_id}/controls/{normalized_control_id}/references",
+        )
         return ControlReferences(**data)
 
     async def get_controls_metadata(self, framework_id: str | None = None) -> dict[str, ControlMetadata]:
@@ -357,10 +370,21 @@ class PretorianClient:
         Raises:
             PretorianClientError: If the submission fails.
         """
+        payload = artifact.model_dump()
+        if payload.get("control_id"):
+            payload["control_id"] = normalize_control_id(payload["control_id"])
+        component = payload.get("component")
+        if isinstance(component, dict):
+            implementations = component.get("control_implementations")
+            if isinstance(implementations, list):
+                for implementation in implementations:
+                    if isinstance(implementation, dict) and implementation.get("control_id"):
+                        implementation["control_id"] = normalize_control_id(implementation["control_id"])
+
         data = await self._request(
             "POST",
             "/artifacts",
-            json=artifact.model_dump(),
+            json=payload,
         )
         return data
 
@@ -428,7 +452,7 @@ class PretorianClient:
         """
         params: dict[str, Any] = {"limit": limit}
         if control_id:
-            params["control_id"] = control_id
+            params["control_id"] = normalize_control_id(control_id)
         if framework_id:
             params["framework_id"] = framework_id
 
@@ -464,6 +488,8 @@ class PretorianClient:
             Created evidence response.
         """
         payload = evidence.model_dump(exclude_none=True)
+        if payload.get("control_id"):
+            payload["control_id"] = normalize_control_id(payload["control_id"])
         data = await self._request(
             "POST",
             f"/systems/{system_id}/evidence",
@@ -489,7 +515,7 @@ class PretorianClient:
         Returns:
             Link result.
         """
-        payload: dict[str, Any] = {"control_id": control_id}
+        payload: dict[str, Any] = {"control_id": normalize_control_id(control_id)}
         if framework_id:
             payload["framework_id"] = framework_id
         path = f"/systems/{system_id}/evidence/{evidence_id}/link" if system_id else f"/evidence/{evidence_id}/link"
@@ -519,9 +545,10 @@ class PretorianClient:
         params: dict[str, Any] = {}
         if framework_id:
             params["framework_id"] = framework_id
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "GET",
-            f"/systems/{system_id}/controls/{control_id}/narrative",
+            f"/systems/{system_id}/controls/{normalized_control_id}/narrative",
             params=params,
         )
         return NarrativeResponse(**data)
@@ -549,9 +576,10 @@ class PretorianClient:
         params: dict[str, Any] = {}
         if framework_id:
             params["framework_id"] = framework_id
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "GET",
-            f"/systems/{system_id}/controls/{control_id}",
+            f"/systems/{system_id}/controls/{normalized_control_id}",
             params=params,
         )
         return ControlImplementationResponse(**data)
@@ -572,9 +600,10 @@ class PretorianClient:
         Returns:
             ControlContext with combined OSCAL + implementation data.
         """
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "GET",
-            f"/systems/{system_id}/controls/{control_id}/context",
+            f"/systems/{system_id}/controls/{normalized_control_id}/context",
             params={"framework_id": framework_id},
         )
         return ControlContext(**data)
@@ -599,9 +628,10 @@ class PretorianClient:
         Returns:
             Updated control implementation data.
         """
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "POST",
-            f"/systems/{system_id}/controls/{control_id}/narrative",
+            f"/systems/{system_id}/controls/{normalized_control_id}/narrative",
             params={"framework_id": framework_id},
             json={"narrative": narrative, "is_ai_generated": is_ai_generated},
         )
@@ -640,9 +670,10 @@ class PretorianClient:
             Created note response.
         """
         payload = {"content": content, "source": source}
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "POST",
-            f"/systems/{system_id}/controls/{control_id}/notes",
+            f"/systems/{system_id}/controls/{normalized_control_id}/notes",
             params={"framework_id": framework_id},
             json=payload,
         )
@@ -669,9 +700,10 @@ class PretorianClient:
         params: dict[str, Any] = {}
         if framework_id:
             params["framework_id"] = framework_id
+        normalized_control_id = self._normalize_control_id(control_id)
         data = await self._request(
             "POST",
-            f"/systems/{system_id}/controls/{control_id}/status",
+            f"/systems/{system_id}/controls/{normalized_control_id}/status",
             params=params,
             json={"status": status},
         )
@@ -695,9 +727,13 @@ class PretorianClient:
         Returns:
             Created event response.
         """
+        payload = event.model_dump(exclude_none=True)
+        if payload.get("control_id"):
+            payload["control_id"] = normalize_control_id(payload["control_id"])
+
         data = await self._request(
             "POST",
             f"/systems/{system_id}/monitoring/events",
-            json=event.model_dump(exclude_none=True),
+            json=payload,
         )
         return data

--- a/src/pretorin/client/models.py
+++ b/src/pretorin/client/models.py
@@ -195,7 +195,7 @@ class Evidence(BaseModel):
 class ImplementationStatement(BaseModel):
     """Implementation statement for a specific control."""
 
-    control_id: str = Field(..., description="Control ID (e.g., ac-2, au-2)")
+    control_id: str = Field(..., description="Control ID (e.g., ac-02, au-02)")
     description: str = Field(
         ...,
         description="2-3 sentence narrative of how control is implemented",
@@ -238,7 +238,7 @@ class ComplianceArtifact(BaseModel):
     """A compliance artifact containing implementation evidence for a control."""
 
     framework_id: str = Field(..., description="Framework ID (e.g., fedramp-moderate)")
-    control_id: str = Field(..., description="Control ID (e.g., ac-2)")
+    control_id: str = Field(..., description="Control ID (e.g., ac-02)")
     component: ComponentDefinition = Field(..., description="Component definition")
     confidence: Literal["high", "medium", "low"] = Field(
         default="medium",

--- a/src/pretorin/mcp/analysis_prompts.py
+++ b/src/pretorin/mcp/analysis_prompts.py
@@ -23,7 +23,7 @@ ARTIFACT_SCHEMA = {
     "control_id": {
         "type": "string",
         "required": True,
-        "description": "The control ID being addressed (e.g., ac-2, au-2)",
+        "description": "The control ID being addressed (e.g., ac-02, au-02)",
     },
     "component": {
         "type": "object",
@@ -121,7 +121,7 @@ When analyzing code for compliance, produce a JSON artifact with this structure:
 ```json
 {
   "framework_id": "fedramp-moderate",
-  "control_id": "ac-2",
+  "control_id": "ac-02",
   "component": {
     "component_id": "my-application",
     "title": "My Application",
@@ -129,7 +129,7 @@ When analyzing code for compliance, produce a JSON artifact with this structure:
     "type": "software",
     "control_implementations": [
       {
-        "control_id": "ac-2",
+        "control_id": "ac-02",
         "description": "The application implements account management through...",
         "implementation_status": "implemented",
         "responsible_roles": ["System Administrator", "Security Team"],
@@ -290,13 +290,13 @@ non-federal systems. It's a subset of 800-53 with ~110 requirements.
 
 CONTROL_ANALYSIS_PROMPTS: dict[str, dict[str, str]] = {
     # -------------------------------------------------------------------------
-    # AC-2: Account Management
+    # AC-02: Account Management
     # -------------------------------------------------------------------------
     "ac-02": {
         "title": "Account Management",
         "family": "Access Control",
         "summary": """
-AC-2 requires organizations to manage system accounts including identifying
+AC-02 requires organizations to manage system accounts including identifying
 account types, assigning account managers, establishing conditions for group
 membership, specifying authorized users, and maintaining ongoing account
 administration.
@@ -380,13 +380,13 @@ not just that relevant code exists.
 """,
     },
     # -------------------------------------------------------------------------
-    # AU-2: Audit Events
+    # AU-02: Audit Events
     # -------------------------------------------------------------------------
     "au-02": {
         "title": "Audit Events",
         "family": "Audit and Accountability",
         "summary": """
-AU-2 requires identifying events that need to be audited, coordinating the
+AU-02 requires identifying events that need to be audited, coordinating the
 audit function with other organizational entities, and determining which
 events require auditing based on risk assessments.
 """,
@@ -464,13 +464,13 @@ log4j*.xml
 """,
     },
     # -------------------------------------------------------------------------
-    # IA-2: Identification and Authentication
+    # IA-02: Identification and Authentication
     # -------------------------------------------------------------------------
     "ia-02": {
         "title": "Identification and Authentication (Organizational Users)",
         "family": "Identification and Authentication",
         "summary": """
-IA-2 requires uniquely identifying and authenticating organizational users
+IA-02 requires uniquely identifying and authenticating organizational users
 (or processes acting on behalf of users). This includes implementing
 multi-factor authentication for various access types.
 """,
@@ -553,13 +553,13 @@ multi-factor authentication for various access types.
 """,
     },
     # -------------------------------------------------------------------------
-    # SC-7: Boundary Protection
+    # SC-07: Boundary Protection
     # -------------------------------------------------------------------------
     "sc-07": {
         "title": "Boundary Protection",
         "family": "System and Communications Protection",
         "summary": """
-SC-7 requires monitoring and controlling communications at external and
+SC-07 requires monitoring and controlling communications at external and
 key internal boundaries of the system. This includes implementing managed
 interfaces with traffic control and enforcing network segmentation.
 """,
@@ -644,13 +644,13 @@ interfaces with traffic control and enforcing network segmentation.
 """,
     },
     # -------------------------------------------------------------------------
-    # CM-2: Baseline Configuration
+    # CM-02: Baseline Configuration
     # -------------------------------------------------------------------------
     "cm-02": {
         "title": "Baseline Configuration",
         "family": "Configuration Management",
         "summary": """
-CM-2 requires developing, documenting, and maintaining a current baseline
+CM-02 requires developing, documenting, and maintaining a current baseline
 configuration of the system. This includes configuration settings, software
 versions, and security configurations.
 """,
@@ -781,11 +781,14 @@ def get_control_prompt(control_id: str) -> dict[str, str] | None:
 
 def format_control_analysis_prompt(framework_id: str, control_id: str) -> str:
     """Format a complete analysis prompt for a control."""
-    prompt_data = get_control_prompt(control_id)
+    from pretorin.utils import normalize_control_id
+
+    normalized_control_id = normalize_control_id(control_id)
+    prompt_data = get_control_prompt(normalized_control_id)
 
     if not prompt_data:
         return f"""
-# Control Analysis: {control_id.upper()}
+# Control Analysis: {normalized_control_id.upper()}
 
 No specific analysis guidance available for this control.
 
@@ -803,7 +806,7 @@ Use the schema from `analysis://schema` to format your artifact.
 """
 
     return f"""
-# Control Analysis: {control_id.upper()} - {prompt_data["title"]}
+# Control Analysis: {normalized_control_id.upper()} - {prompt_data["title"]}
 
 **Family:** {prompt_data["family"]}
 
@@ -819,7 +822,7 @@ Use the schema from `analysis://schema` to format your artifact.
 ## Output Format
 
 Produce a JSON artifact following the schema from `analysis://schema`.
-Set the framework_id to `{framework_id}` and control_id to `{control_id}`.
+Set the framework_id to `{framework_id}` and control_id to `{normalized_control_id}`.
 
 After analysis, validate with `pretorin_validate_artifact` and submit
 with `pretorin_submit_artifact`.

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -73,6 +73,22 @@ _VALID_EVIDENCE_TYPES = {
 _VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
 _VALID_EVENT_TYPES = {"security_scan", "configuration_change", "access_review", "compliance_check"}
 _VALID_CONTROL_STATUSES = {"implemented", "partial", "planned", "not_started", "not_applicable"}
+_CONTROL_ID_DESCRIPTION = (
+    "The control ID. Use canonical IDs from list_controls. "
+    "NIST/FedRAMP IDs are zero-padded (e.g., ac-02). "
+    "CMMC IDs use dotted notation (e.g., AC.L2-3.1.1)."
+)
+_CONTROL_ID_EXAMPLES = ["ac-02", "sc-07", "AC.L2-3.1.1", "03.01.01"]
+
+
+def _control_id_property(*, optional: bool = False) -> dict[str, Any]:
+    """Return a shared JSON schema field for control_id parameters."""
+    description = _CONTROL_ID_DESCRIPTION if not optional else f"Optional: {_CONTROL_ID_DESCRIPTION}"
+    return {
+        "type": "string",
+        "description": description,
+        "examples": _CONTROL_ID_EXAMPLES,
+    }
 
 
 def _require(arguments: dict[str, Any], *keys: str) -> str | None:
@@ -267,10 +283,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The framework ID (e.g., nist-800-53-r5)",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                 },
                 "required": ["framework_id", "control_id"],
             },
@@ -285,10 +298,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The framework ID (e.g., nist-800-53-r5)",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                 },
                 "required": ["framework_id", "control_id"],
             },
@@ -354,10 +364,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "control_id": {
-                        "type": "string",
-                        "description": "Optional: Filter by control ID",
-                    },
+                    "control_id": _control_id_property(optional=True),
                     "framework_id": {
                         "type": "string",
                         "description": "Optional: Filter by framework ID",
@@ -395,10 +402,7 @@ async def list_tools() -> list[Tool]:
                         "default": "documentation",
                         "enum": sorted(_VALID_EVIDENCE_TYPES),
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "Optional: Associated control ID",
-                    },
+                    "control_id": _control_id_property(optional=True),
                     "framework_id": {
                         "type": "string",
                         "description": "Optional: Associated framework ID",
@@ -421,10 +425,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The evidence item ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID to link to",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "Optional: Framework context for the link",
@@ -444,10 +445,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "Optional: Framework ID filter",
@@ -483,10 +481,7 @@ async def list_tools() -> list[Tool]:
                         "default": "security_scan",
                         "enum": sorted(_VALID_EVENT_TYPES),
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "Optional: Associated control ID",
-                    },
+                    "control_id": _control_id_property(optional=True),
                     "description": {
                         "type": "string",
                         "description": "Optional: Detailed event description",
@@ -509,10 +504,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID (e.g., ac-2)",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "The framework ID (e.g., nist-800-53-r5)",
@@ -545,10 +537,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "The framework ID",
@@ -579,10 +568,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "The framework ID",
@@ -606,10 +592,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                     "status": {
                         "type": "string",
                         "description": "New implementation status",
@@ -635,10 +618,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "The system ID",
                     },
-                    "control_id": {
-                        "type": "string",
-                        "description": "The control ID",
-                    },
+                    "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "Optional: Framework ID filter",

--- a/tests/test_analysis_prompts.py
+++ b/tests/test_analysis_prompts.py
@@ -144,7 +144,8 @@ class TestFormatControlAnalysisPrompt:
     def test_known_control_formatting(self):
         """Test formatting for known control."""
         prompt = format_control_analysis_prompt("fedramp-moderate", "ac-2")
-        assert "AC-2" in prompt
+        assert "AC-02" in prompt
+        assert "control_id to `ac-02`" in prompt
         assert "Account Management" in prompt
         assert "fedramp-moderate" in prompt
         assert "analysis://schema" in prompt

--- a/tests/test_control_id_normalization.py
+++ b/tests/test_control_id_normalization.py
@@ -1,0 +1,105 @@
+"""Tests for control ID normalization across client and agent paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pretorin.agent.tools import create_platform_tools
+from pretorin.client.api import PretorianClient
+from pretorin.client.models import ComplianceArtifact, ComponentDefinition, EvidenceCreate, ImplementationStatement
+
+
+@pytest.mark.asyncio
+async def test_client_get_control_normalizes_control_id_in_path() -> None:
+    client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
+    client._request = AsyncMock(return_value={"id": "ac-02", "title": "Account Management"})  # type: ignore[method-assign]
+
+    await client.get_control("fedramp-moderate", "ac-2")
+
+    client._request.assert_awaited_once_with("GET", "/frameworks/fedramp-moderate/controls/ac-02")
+
+
+@pytest.mark.asyncio
+async def test_client_create_evidence_normalizes_control_id_in_payload() -> None:
+    client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
+    client._request = AsyncMock(return_value={"id": "ev-1"})  # type: ignore[method-assign]
+
+    evidence = EvidenceCreate(
+        name="RBAC config",
+        description="Role mapping",
+        control_id="ac-2",
+        framework_id="fedramp-moderate",
+    )
+    await client.create_evidence("sys-1", evidence)
+
+    client._request.assert_awaited_once()
+    _method, _path = client._request.await_args.args
+    payload = client._request.await_args.kwargs["json"]
+    assert payload["control_id"] == "ac-02"
+
+
+@pytest.mark.asyncio
+async def test_client_submit_artifact_normalizes_root_and_nested_control_ids() -> None:
+    client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
+    client._request = AsyncMock(return_value={"artifact_id": "art-1"})  # type: ignore[method-assign]
+
+    artifact = ComplianceArtifact(
+        framework_id="fedramp-moderate",
+        control_id="ac-2",
+        component=ComponentDefinition(
+            component_id="app",
+            title="App",
+            description="Service",
+            control_implementations=[
+                ImplementationStatement(
+                    control_id="ac-2",
+                    description="Implemented with RBAC",
+                    implementation_status="implemented",
+                )
+            ],
+        ),
+    )
+    await client.submit_artifact(artifact)
+
+    client._request.assert_awaited_once()
+    payload = client._request.await_args.kwargs["json"]
+    assert payload["control_id"] == "ac-02"
+    assert payload["component"]["control_implementations"][0]["control_id"] == "ac-02"
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_update_control_status_normalizes_control_id() -> None:
+    mock_client = AsyncMock()
+    mock_client.update_control_status = AsyncMock(return_value={"ok": True})
+
+    tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
+    await tools["update_control_status"].handler(
+        system_id="sys-1",
+        control_id="ac-2",
+        status="implemented",
+        framework_id="fedramp-moderate",
+    )
+
+    mock_client.update_control_status.assert_awaited_once_with(
+        "sys-1",
+        "ac-02",
+        "implemented",
+        "fedramp-moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_search_evidence_normalizes_control_id_filter() -> None:
+    mock_client = AsyncMock()
+    mock_client.list_evidence = AsyncMock(return_value=[])
+
+    tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
+    await tools["search_evidence"].handler(control_id="ac-2", framework_id="fedramp-moderate", limit=10)
+
+    mock_client.list_evidence.assert_awaited_once_with(
+        control_id="ac-02",
+        framework_id="fedramp-moderate",
+        limit=10,
+    )

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -68,6 +68,27 @@ class TestToolListing:
             assert tool.inputSchema, f"Tool {tool.name} has no input schema"
             assert tool.inputSchema.get("type") == "object"
 
+    def test_control_id_schemas_use_shared_guidance(self) -> None:
+        tools = asyncio.run(list_tools())
+        with_control_id = [t for t in tools if "control_id" in t.inputSchema.get("properties", {})]
+
+        assert with_control_id, "Expected at least one tool with a control_id parameter"
+
+        for tool in with_control_id:
+            control_field = tool.inputSchema["properties"]["control_id"]
+            description = control_field.get("description", "")
+            required = tool.inputSchema.get("required", [])
+
+            assert "zero-padded" in description
+            assert "ac-02" in description
+            assert "AC.L2-3.1.1" in description
+            assert control_field.get("examples") == ["ac-02", "sc-07", "AC.L2-3.1.1", "03.01.01"]
+
+            if "control_id" in required:
+                assert not description.startswith("Optional:")
+            else:
+                assert description.startswith("Optional:")
+
 
 def _make_mock_client(**overrides: Any) -> AsyncMock:
     """Create a properly configured mock PretorianClient."""
@@ -151,6 +172,7 @@ class TestEvidenceTools:
         data = _parse_result(result)
         assert data["total"] == 1
         assert data["evidence"][0]["name"] == "RBAC Config"
+        client.list_evidence.assert_awaited_once_with(control_id="ac-02", framework_id=None, limit=20)
 
     def test_create_evidence(self) -> None:
         client = _make_mock_client(create_evidence={"id": "ev-new", "name": "New Evidence"})
@@ -176,6 +198,12 @@ class TestEvidenceTools:
         )
         data = _parse_result(result)
         assert data["linked"] is True
+        client.link_evidence_to_control.assert_awaited_once_with(
+            evidence_id="ev-1",
+            control_id="ac-02",
+            system_id="sys-1",
+            framework_id=None,
+        )
 
     def test_link_evidence_missing_system_id(self) -> None:
         client = _make_mock_client()
@@ -200,6 +228,7 @@ class TestNarrativeTools:
         result = _run_tool("pretorin_get_narrative", {"system_id": "sys-1", "control_id": "ac-2"}, client)
         data = _parse_result(result)
         assert data["narrative"] == "Existing narrative"
+        client.get_narrative.assert_awaited_once_with(system_id="sys-1", control_id="ac-02", framework_id=None)
 
 
 class TestMonitoringTools:
@@ -247,6 +276,12 @@ class TestControlImplementationTools:
         )
         data = _parse_result(result)
         assert data["status"] == "implemented"
+        client.update_control_status.assert_awaited_once_with(
+            system_id="sys-1",
+            control_id="ac-02",
+            status="implemented",
+            framework_id=None,
+        )
 
     def test_get_control_implementation(self) -> None:
         from pretorin.client.models import ControlImplementationResponse
@@ -270,6 +305,11 @@ class TestControlImplementationTools:
         data = _parse_result(result)
         assert data["control_id"] == "ac-2"
         assert data["evidence_count"] == 3
+        client.get_control_implementation.assert_awaited_once_with(
+            system_id="sys-1",
+            control_id="ac-02",
+            framework_id=None,
+        )
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Summary
- shorten `server.json` description to satisfy MCP registry schema limit (`<=100` chars)
- keep wording concise and accurate for Pretorin CLI/MCP capabilities

## Why
Recent release workflows failed at `Publish to MCP Registry` during `mcp-publisher validate` with HTTP 422 due to description length.

## Validation
- new description length: 90 chars
- file: `server.json`
