### PR TITLE
qa/2026-03-05 demo walkthrough and table display fixes

### DIFF
--- a/scripts/demo-walkthrough.sh
+++ b/scripts/demo-walkthrough.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 # ── Pretorin CLI Demo Walkthrough ─────────────────────────────────────────────
 # Guided tour of the full Pretorin CLI workflow for new beta users.
@@ -45,7 +45,13 @@ pause() {
 run_cmd() {
     echo -e "  ${DIM}\$ $*${RESET}"
     echo ""
-    "$@"
+    if ! "$@"; then
+        echo ""
+        echo -e "  ${GOLD}⚠ Command failed:${RESET} $*"
+        echo -e "  ${DIM}Continuing...${RESET}"
+        echo ""
+        return 1
+    fi
     echo ""
 }
 
@@ -131,8 +137,33 @@ echo -e "  ${BOLD}If no systems appeared above, create one at platform.pretorin.
 echo -e "  ${DIM}(The demo will continue — 'context set' will fail if no systems exist.)${RESET}"
 echo ""
 
+# Show which systems have fedramp-moderate before the picker
+FEDRAMP_SYSTEMS=$(pretorin --json context list 2>/dev/null | python3 -c "
+import sys, json
+try:
+    rows = json.load(sys.stdin)
+    names = sorted(set(r['system_name'] for r in rows if r.get('framework_id') == 'fedramp-moderate'))
+    if names:
+        for n in names:
+            print(n)
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+
+if [[ -n "$FEDRAMP_SYSTEMS" ]]; then
+    echo -e "  ${BOLD}Systems with fedramp-moderate attached:${RESET}"
+    while IFS= read -r sysname; do
+        echo -e "    ✓ ${sysname}"
+    done <<< "$FEDRAMP_SYSTEMS"
+    echo ""
+else
+    echo -e "  ${GOLD}⚠ No systems with fedramp-moderate detected.${RESET}"
+    echo -e "  ${DIM}Attach fedramp-moderate to a system at https://platform.pretorin.com before continuing.${RESET}"
+    echo ""
+fi
+
 echo -e "  ${BOLD}Select your active system (interactive picker):${RESET}"
-echo -e "  ${DIM}This demo requires fedramp-moderate — select a system that has it.${RESET}"
+echo -e "  ${DIM}Pick one of the fedramp-moderate systems listed above.${RESET}"
 echo ""
 if ! pretorin context set; then
     echo ""
@@ -190,18 +221,25 @@ pause "Section 3: Create and push evidence"
 
 DEMO_EVIDENCE_DIR="./evidence"
 
+SECTION3_OK=true
+
 echo -e "  ${BOLD}Create a local evidence file for AC-02:${RESET}"
-run_cmd pretorin evidence create ac-02 fedramp-moderate \
+if ! run_cmd pretorin evidence create ac-02 fedramp-moderate \
     -d "Role-based access control audit completed for demo walkthrough. All users verified against approved role matrix." \
-    -n "Demo RBAC Evidence"
+    -n "Demo RBAC Evidence"; then
+    echo -e "  ${GOLD}⚠ Evidence creation failed — skipping rest of Section 3.${RESET}"
+    SECTION3_OK=false
+fi
 
-echo -e "  ${BOLD}List local evidence:${RESET}"
-run_cmd pretorin evidence list
+if $SECTION3_OK; then
+    echo -e "  ${BOLD}List local evidence:${RESET}"
+    run_cmd pretorin evidence list || true
 
-pause "Push evidence to the platform"
+    pause "Push evidence to the platform"
 
-echo -e "  ${BOLD}Push evidence to the platform:${RESET}"
-run_cmd pretorin evidence push
+    echo -e "  ${BOLD}Push evidence to the platform:${RESET}"
+    run_cmd pretorin evidence push || true
+fi
 
 # ── Section 4: Narrative Workflow ────────────────────────────────────────────
 
@@ -245,7 +283,7 @@ pause "Push narrative to the platform"
 
 if [[ -n "$ACTIVE_SYSTEM" ]]; then
     echo -e "  ${BOLD}Push narrative to platform:${RESET}"
-    run_cmd pretorin narrative push ac-02 fedramp-moderate "$ACTIVE_SYSTEM" "$TEMP_NARRATIVE"
+    run_cmd pretorin narrative push ac-02 fedramp-moderate "$ACTIVE_SYSTEM" "$TEMP_NARRATIVE" || true
 else
     echo -e "  ${GOLD}Skipping narrative push — could not detect active system name.${RESET}"
     echo -e "  ${DIM}Run manually: pretorin narrative push ac-02 fedramp-moderate <system> ${TEMP_NARRATIVE}${RESET}"
@@ -260,14 +298,14 @@ run_cmd pretorin monitoring push \
     -t "Demo: Access review completed" \
     --severity info \
     --control ac-02 \
-    --event-type access_review
+    --event-type access_review || true
 
 # ── Section 6: Agent Skills (informational) ──────────────────────────────────
 
 pause "Section 6: Agent skills (informational)"
 
 echo -e "  ${BOLD}List available agent skills:${RESET}"
-run_cmd pretorin agent skills
+run_cmd pretorin agent skills || true
 
 echo ""
 echo -e "  ${DIM}The agent can run compliance tasks using an LLM backend.${RESET}"

--- a/src/pretorin/cli/commands.py
+++ b/src/pretorin/cli/commands.py
@@ -65,12 +65,12 @@ def frameworks_list() -> None:
                     show_header=True,
                     header_style="bold",
                 )
-                table.add_column("ID", style="cyan")
-                table.add_column("Title")
-                table.add_column("Version")
-                table.add_column("Tier")
-                table.add_column("Families", justify="right")
-                table.add_column("Controls", justify="right")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("Title", max_width=60)
+                table.add_column("Version", no_wrap=True)
+                table.add_column("Tier", no_wrap=True)
+                table.add_column("Families", justify="right", no_wrap=True)
+                table.add_column("Controls", justify="right", no_wrap=True)
 
                 tier_colors = {
                     "foundational": "#95D7E0",  # Light Turquoise
@@ -80,9 +80,12 @@ def frameworks_list() -> None:
 
                 for fw in result.frameworks:
                     tier_color = tier_colors.get(fw.tier or "", "white")
+                    title = fw.title
+                    if len(title) > 60:
+                        title = title[:57] + "..."
                     table.add_row(
                         fw.external_id,
-                        fw.title,
+                        title,
                         fw.version,
                         f"[{tier_color}]{fw.tier or '-'}[/{tier_color}]",
                         str(fw.families_count),
@@ -194,10 +197,10 @@ def framework_families(
                     show_header=True,
                     header_style="bold",
                 )
-                table.add_column("ID", style="cyan")
-                table.add_column("Title")
-                table.add_column("Class")
-                table.add_column("Controls", justify="right")
+                table.add_column("ID", style="cyan", no_wrap=True)
+                table.add_column("Title", max_width=50)
+                table.add_column("Class", no_wrap=True)
+                table.add_column("Controls", justify="right", no_wrap=True)
 
                 for family in families:
                     table.add_row(


### PR DESCRIPTION
Two fixes:

Demo walkthrough script:
1. Script was crashing at Section 3 (evidence create) due to missing evidence module, killing the entire demo. Removed -e from set -euo pipefail so it doesnt exit on first failure
2. run_cmd now catches failures and prints a warning instead of crashing
3. Section 3 skips remaining steps if evidence create fails, Sections 4-6 handle failures gracefully
4. Added a hint before the system picker showing which systems have fedramp-moderate attached

Table display:
5. frameworks list was wrapping long titles across 12+ lines and truncating Tier/Families/Controls columns. Added no_wrap on key columns and max_width=60 on Title with clean ellipsis
6. frameworks families had the same issue with long family IDs getting cut off. Added no_wrap on ID/Class/Controls and max_width=50 on Title

All tests pass.