### PR TITLE
Release 0.7.0 with MCP compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Pretorin CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-03-07
+
+### Fixed
+- Made control implementation parsing tolerant of deployments that return `notes: null`, preventing narrative and implementation read crashes on untouched controls
+- Added compatibility fallback for control note reads when the dedicated `/notes` endpoint returns `405 Method Not Allowed`
+- Added compatibility fallback for evidence search on deployments that only expose system-scoped evidence routes
+- Prevented `pretorin agent run --no-stream` from crashing when model output includes literal `[[PRETORIN_TODO]]` blocks
+
+### Changed
+- MCP and legacy agent evidence search tools now accept optional `system_id` context and use the same compatibility search path as the CLI
+
+## [0.6.1] - 2026-03-05
+
+### Fixed
+- Added required MCP registry ownership marker (`mcp-name: io.github.pretorin-ai/pretorin`) to PyPI README metadata so MCP registry publish validation succeeds
+
 ## [0.6.0] - 2026-03-05
 
 ### Added
@@ -173,6 +189,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMMC Level 1, 2, and 3
 - Additional frameworks available on the platform
 
+[0.7.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.5.6...v0.6.0
 [0.5.4]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.5.2...v0.5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/pretorin/agent/tools.py
+++ b/src/pretorin/agent/tools.py
@@ -151,11 +151,13 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
     # --- Evidence ---
 
     async def search_evidence(
+        system_id: str | None = None,
         control_id: str | None = None,
         framework_id: str | None = None,
         limit: int = 20,
     ) -> str:
-        evidence = await client.list_evidence(
+        evidence = await client.search_evidence_with_fallback(
+            system_id=system_id,
             control_id=_normalize(control_id),
             framework_id=framework_id,
             limit=limit,
@@ -169,6 +171,7 @@ def create_platform_tools(client: PretorianClient) -> list[ToolDefinition]:
             parameters={
                 "type": "object",
                 "properties": {
+                    "system_id": {"type": "string", "description": "Optional system ID for system-scoped search"},
                     "control_id": {"type": "string", "description": "Control ID filter"},
                     "framework_id": {"type": "string", "description": "Framework ID filter"},
                     "limit": {"type": "integer", "description": "Max results", "default": 20},

--- a/src/pretorin/cli/agent.py
+++ b/src/pretorin/cli/agent.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import typer
 from rich import print as rprint
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from pretorin.cli.output import is_json_mode, print_json
@@ -127,12 +128,12 @@ async def _run_codex_agent(
             if is_json_mode():
                 print_json({"response": result.response, "evidence_created": result.evidence_created})
             else:
-                rprint(result.response)
+                console.print(result.response, markup=False)
     except RuntimeError as e:
-        rprint(f"[red]Agent error: {e}[/red]")
+        rprint(f"[red]Agent error: {escape(str(e))}[/red]")
         raise typer.Exit(1)
     except Exception as e:
-        rprint(f"[red]Agent error: {e}[/red]")
+        rprint(f"[red]Agent error: {escape(str(e))}[/red]")
         raise typer.Exit(1)
 
 

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -463,6 +463,52 @@ class PretorianClient:
         items = data if isinstance(data, list) else data.get("items", data.get("evidence", []))
         return [EvidenceItemResponse(**item) for item in items]
 
+    async def search_evidence_with_fallback(
+        self,
+        system_id: str | None = None,
+        control_id: str | None = None,
+        framework_id: str | None = None,
+        limit: int = 20,
+    ) -> list[EvidenceItemResponse]:
+        """Search evidence with compatibility fallbacks for system-only deployments."""
+        try:
+            return await self.list_evidence(
+                system_id=system_id,
+                control_id=control_id,
+                framework_id=framework_id,
+                limit=limit,
+            )
+        except NotFoundError:
+            if system_id is not None:
+                raise
+        except PretorianClientError as exc:
+            if exc.status_code not in {404, 405} or system_id is not None:
+                raise
+
+        systems = await self.list_systems()
+        results: list[EvidenceItemResponse] = []
+        seen_ids: set[str] = set()
+        for system in systems:
+            candidate_id = str(system.get("id", ""))
+            if not candidate_id:
+                continue
+            try:
+                scoped = await self.list_evidence(
+                    system_id=candidate_id,
+                    control_id=control_id,
+                    framework_id=framework_id,
+                    limit=limit,
+                )
+            except PretorianClientError:
+                continue
+            for item in scoped:
+                if item.id not in seen_ids:
+                    seen_ids.add(item.id)
+                    results.append(item)
+                    if len(results) >= limit:
+                        return results
+        return results
+
     async def get_evidence(self, evidence_id: str) -> EvidenceItemResponse:
         """Get a specific evidence item.
 
@@ -712,14 +758,20 @@ class PretorianClient:
         if framework_id:
             params["framework_id"] = framework_id
         normalized_control_id = self._normalize_control_id(control_id)
-        data = await self._request(
-            "GET",
-            f"/systems/{system_id}/controls/{normalized_control_id}/notes",
-            params=params,
-        )
-        if isinstance(data, list):
-            return data
-        return data.get("notes", data.get("items", []))
+        try:
+            data = await self._request(
+                "GET",
+                f"/systems/{system_id}/controls/{normalized_control_id}/notes",
+                params=params,
+            )
+            if isinstance(data, list):
+                return data
+            return data.get("notes", data.get("items", []))
+        except PretorianClientError as exc:
+            if exc.status_code != 405:
+                raise
+            impl = await self.get_control_implementation(system_id, normalized_control_id or "", framework_id)
+            return impl.notes
 
     async def update_control_status(
         self,

--- a/src/pretorin/client/models.py
+++ b/src/pretorin/client/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # =============================================================================
 # Framework Models
@@ -352,6 +352,14 @@ class ControlImplementationResponse(BaseModel):
     ai_confidence_score: float | None = None
     evidence_count: int = 0
     notes: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("notes", mode="before")
+    @classmethod
+    def _coerce_null_notes(cls, value: Any) -> list[dict[str, Any]]:
+        """Treat null notes from older platform deployments as an empty list."""
+        if value is None:
+            return []
+        return value
 
     @property
     def narrative(self) -> str | None:

--- a/src/pretorin/client/models.py
+++ b/src/pretorin/client/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -359,7 +359,7 @@ class ControlImplementationResponse(BaseModel):
         """Treat null notes from older platform deployments as an empty list."""
         if value is None:
             return []
-        return value
+        return cast(list[dict[str, Any]], value)
 
     @property
     def narrative(self) -> str | None:

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -376,6 +376,10 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "system_id": {
+                        "type": "string",
+                        "description": "Optional: search one system directly instead of org/global scope",
+                    },
                     "control_id": _control_id_property(optional=True),
                     "framework_id": {
                         "type": "string",
@@ -937,7 +941,8 @@ async def _handle_search_evidence(
 ) -> list[TextContent]:
     """Handle the search_evidence tool."""
     raw_control_id = arguments.get("control_id")
-    evidence = await client.list_evidence(
+    evidence = await client.search_evidence_with_fallback(
+        system_id=arguments.get("system_id"),
         control_id=normalize_control_id(raw_control_id) if raw_control_id else None,
         framework_id=arguments.get("framework_id"),
         limit=arguments.get("limit", 20),
@@ -945,6 +950,7 @@ async def _handle_search_evidence(
     return _format_json(
         {
             "total": len(evidence),
+            "system_id": arguments.get("system_id"),
             "evidence": [
                 {
                     "id": e.id,

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -131,6 +131,35 @@ class TestAgentRunCLI:
             mock_asyncio.run.side_effect = self._close_coroutine
             runner.invoke(agent_cli.app, ["run", "test task", "--legacy"])
             mock_asyncio.run.assert_called_once()
+
+
+class TestAgentRunRendering:
+    """Tests for output rendering safety."""
+
+    @pytest.mark.asyncio
+    async def test_run_codex_agent_prints_todo_blocks_without_markup(self) -> None:
+        result = MagicMock()
+        result.response = "[[/PRETORIN_TODO]]"
+        result.evidence_created = []
+
+        mock_agent = MagicMock()
+        mock_agent.model = "gpt-4o"
+        mock_agent.run = AsyncMock(return_value=result)
+
+        with (
+            patch("pretorin.agent.codex_agent.CodexAgent", return_value=mock_agent),
+            patch("pretorin.cli.agent.console.print") as mock_print,
+        ):
+            await agent_cli._run_codex_agent(
+                message="test",
+                skill=None,
+                model=None,
+                base_url=None,
+                working_dir=None,
+                stream=False,
+            )
+
+        mock_print.assert_called_with("[[/PRETORIN_TODO]]", markup=False)
 
 
 class TestHarnessDeprecation:

--- a/tests/test_control_id_normalization.py
+++ b/tests/test_control_id_normalization.py
@@ -7,8 +7,15 @@ from unittest.mock import AsyncMock
 import pytest
 
 from pretorin.agent.tools import create_platform_tools
-from pretorin.client.api import PretorianClient, PretorianClientError
-from pretorin.client.models import ComplianceArtifact, ComponentDefinition, EvidenceCreate, ImplementationStatement
+from pretorin.client.api import NotFoundError, PretorianClient, PretorianClientError
+from pretorin.client.models import (
+    ComplianceArtifact,
+    ComponentDefinition,
+    ControlImplementationResponse,
+    EvidenceCreate,
+    EvidenceItemResponse,
+    ImplementationStatement,
+)
 from pretorin.utils import normalize_control_id
 
 
@@ -94,12 +101,13 @@ async def test_agent_tool_update_control_status_normalizes_control_id() -> None:
 @pytest.mark.asyncio
 async def test_agent_tool_search_evidence_normalizes_control_id_filter() -> None:
     mock_client = AsyncMock()
-    mock_client.list_evidence = AsyncMock(return_value=[])
+    mock_client.search_evidence_with_fallback = AsyncMock(return_value=[])
 
     tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
     await tools["search_evidence"].handler(control_id="ac-2", framework_id="fedramp-moderate", limit=10)
 
-    mock_client.list_evidence.assert_awaited_once_with(
+    mock_client.search_evidence_with_fallback.assert_awaited_once_with(
+        system_id=None,
         control_id="ac-02",
         framework_id="fedramp-moderate",
         limit=10,
@@ -250,3 +258,67 @@ async def test_agent_tool_get_control_implementation_requires_framework_id() -> 
         "AC.L1-3.1.1",
         "cmmc-l1",
     )
+
+
+@pytest.mark.asyncio
+async def test_client_list_control_notes_falls_back_to_implementation_on_405() -> None:
+    client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
+    client._request = AsyncMock(side_effect=PretorianClientError("Method Not Allowed", status_code=405))  # type: ignore[method-assign]
+    client.get_control_implementation = AsyncMock(  # type: ignore[method-assign]
+        return_value=ControlImplementationResponse(
+            control_id="ac-02",
+            status="partial",
+            implementation_narrative="Narrative",
+            notes=[{"content": "Recovered note"}],
+        )
+    )
+
+    notes = await client.list_control_notes("sys-1", "ac-2", "fedramp-moderate")
+
+    assert notes == [{"content": "Recovered note"}]
+    client.get_control_implementation.assert_awaited_once_with("sys-1", "ac-02", "fedramp-moderate")
+
+
+@pytest.mark.asyncio
+async def test_client_search_evidence_falls_back_to_system_scoped_queries() -> None:
+    client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
+    client.list_evidence = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            NotFoundError("Not Found", status_code=404),
+            [
+                EvidenceItemResponse(
+                    id="ev-1",
+                    name="RBAC Config",
+                    description="- Role mapping",
+                    evidence_type="configuration",
+                )
+            ],
+            [
+                EvidenceItemResponse(
+                    id="ev-1",
+                    name="RBAC Config",
+                    description="- Role mapping",
+                    evidence_type="configuration",
+                ),
+                EvidenceItemResponse(
+                    id="ev-2",
+                    name="Approval Export",
+                    description="- IAM approval workflow",
+                    evidence_type="report",
+                ),
+            ],
+        ]
+    )
+    client.list_systems = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{"id": "sys-1"}, {"id": "sys-2"}]
+    )
+
+    evidence = await client.search_evidence_with_fallback(control_id="ac-2", framework_id="fedramp-moderate", limit=10)
+
+    assert [item.id for item in evidence] == ["ev-1", "ev-2"]
+    assert client.list_evidence.await_args_list[0].kwargs == {
+        "system_id": None,
+        "control_id": "ac-2",
+        "framework_id": "fedramp-moderate",
+        "limit": 10,
+    }

--- a/tests/test_control_id_normalization.py
+++ b/tests/test_control_id_normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -43,8 +44,10 @@ async def test_client_create_evidence_normalizes_control_id_in_payload() -> None
     await client.create_evidence("sys-1", evidence)
 
     client._request.assert_awaited_once()
-    _method, _path = client._request.await_args.args
-    payload = client._request.await_args.kwargs["json"]
+    await_args = client._request.await_args
+    assert await_args is not None
+    _method, _path = await_args.args
+    payload = cast(dict[str, Any], await_args.kwargs["json"])
     assert payload["control_id"] == "ac-02"
 
 
@@ -72,7 +75,9 @@ async def test_client_submit_artifact_normalizes_root_and_nested_control_ids() -
     await client.submit_artifact(artifact)
 
     client._request.assert_awaited_once()
-    payload = client._request.await_args.kwargs["json"]
+    await_args = client._request.await_args
+    assert await_args is not None
+    payload = cast(dict[str, Any], await_args.kwargs["json"])
     assert payload["control_id"] == "ac-02"
     assert payload["component"]["control_implementations"][0]["control_id"] == "ac-02"
 
@@ -228,7 +233,7 @@ async def test_client_get_control_implementation_cmmc_with_framework_id() -> Non
 async def test_client_get_narrative_405_requires_framework_id_for_fallback() -> None:
     client = PretorianClient(api_key="test", api_base_url="https://api.example.com")
 
-    async def fake_request(method: str, path: str, params: dict[str, str] | None = None) -> dict[str, str]:
+    async def fake_request(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         if path.endswith("/narrative"):
             raise PretorianClientError("Method not allowed", status_code=405)
         return {"control_id": "ac-02", "status": "not_started"}

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -168,12 +168,27 @@ class TestEvidenceTools:
                 evidence_type="configuration",
             ),
         ]
-        client = _make_mock_client(list_evidence=evidence)
+        client = _make_mock_client(search_evidence_with_fallback=evidence)
         result = _run_tool("pretorin_search_evidence", {"control_id": "ac-2"}, client)
         data = _parse_result(result)
         assert data["total"] == 1
         assert data["evidence"][0]["name"] == "RBAC Config"
-        client.list_evidence.assert_awaited_once_with(control_id="ac-02", framework_id=None, limit=20)
+        client.search_evidence_with_fallback.assert_awaited_once_with(
+            system_id=None,
+            control_id="ac-02",
+            framework_id=None,
+            limit=20,
+        )
+
+    def test_search_evidence_accepts_system_id(self) -> None:
+        client = _make_mock_client(search_evidence_with_fallback=[])
+        _run_tool("pretorin_search_evidence", {"system_id": "sys-1", "control_id": "ac-2"}, client)
+        client.search_evidence_with_fallback.assert_awaited_once_with(
+            system_id="sys-1",
+            control_id="ac-02",
+            framework_id=None,
+            limit=20,
+        )
 
     def test_create_evidence(self) -> None:
         client = _make_mock_client(

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -377,7 +377,7 @@ class TestControlImplementationTools:
         impl = ControlImplementationResponse(
             control_id="ac-2",
             status="partial",
-            narrative="In progress",
+            implementation_narrative="In progress",
             evidence_count=3,
             notes=[{"content": "Working on it"}],
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from pretorin.client.models import (
     ArtifactValidationResult,
     ComplianceArtifact,
     ComponentDefinition,
+    ControlImplementationResponse,
     Evidence,
     ImplementationStatement,
 )
@@ -224,6 +225,19 @@ class TestComplianceArtifactModel:
                 ),
                 confidence="invalid",
             )
+
+
+class TestControlImplementationModel:
+    """Tests for control implementation compatibility parsing."""
+
+    def test_control_implementation_coerces_null_notes_to_empty_list(self):
+        impl = ControlImplementationResponse(
+            control_id="ac-02",
+            status="partial",
+            implementation_narrative="Narrative",
+            notes=None,
+        )
+        assert impl.notes == []
 
     def test_artifact_model_dump(self):
         """Test artifact serialization to dict."""

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "pretorin"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump Pretorin to `0.7.0` and update the changelog/lockfile
- make control implementation parsing and control-note reads compatible with deployments that return `notes: null` or `405 Method Not Allowed`
- add evidence-search fallbacks for system-scoped deployments and expose optional `system_id` on MCP/agent evidence search
- prevent `pretorin agent run --no-stream` from crashing on literal `[[PRETORIN_TODO]]` output

## Verification
- `uv run pytest tests/test_models.py tests/test_control_id_normalization.py tests/test_mcp_tools_expanded.py tests/test_agent_cli.py tests/test_compliance_cli_commands.py`
- `uv run ruff check src/pretorin tests`
- live smoke tests for CLI, MCP, and direct agent flows against `demo-system` / `fedramp-moderate`
