### PR TITLE
Release 0.8.0 with MCP generation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Pretorin CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-03-07
+
+### Added
+- MCP `pretorin_generate_control_artifacts` for read-only AI drafting of control narratives and evidence-gap assessments using the same Codex workflow as the CLI
+- Shared AI drafting workflow helper for structured MCP/CLI parity around generated compliance artifacts
+
+### Changed
+- MCP system-scoped tools now resolve friendly system names the same way the CLI does, returning canonical system IDs in responses
+- Codex Desktop MCP configuration can be pinned to the UV-managed Pretorin wrapper to avoid PATH drift to incompatible installs
+
 ## [0.7.0] - 2026-03-07
 
 ### Fixed
@@ -189,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMMC Level 1, 2, and 3
 - Additional frameworks available on the platform
 
+[0.8.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.5.6...v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.7.0"
+version = "0.8.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -28,7 +29,8 @@ from pretorin.mcp.analysis_prompts import (
     get_framework_guide,
 )
 from pretorin.utils import normalize_control_id
-from pretorin.workflows.compliance_updates import upsert_evidence
+from pretorin.workflows.ai_generation import draft_control_artifacts
+from pretorin.workflows.compliance_updates import resolve_system, upsert_evidence
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +101,15 @@ def _control_id_property(*, optional: bool = False) -> dict[str, Any]:
     }
 
 
+def _system_id_property(*, optional: bool = False) -> dict[str, Any]:
+    """Return a shared JSON schema field for system_id parameters."""
+    description = "The system ID or name" if not optional else "Optional: The system ID or name"
+    return {
+        "type": "string",
+        "description": description,
+    }
+
+
 def _require(arguments: dict[str, Any], *keys: str) -> str | None:
     """Validate that all keys are present and non-empty.
 
@@ -118,6 +129,22 @@ def _validate_enum(value: str, valid: set[str], field_name: str) -> str | None:
     if value not in valid:
         return f"Invalid {field_name}: {value!r}. Must be one of: {', '.join(sorted(valid))}"
     return None
+
+
+async def _resolve_system_id(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+    *,
+    required: bool = True,
+) -> str | None:
+    """Resolve MCP system_id arguments using the same name/ID rules as the CLI."""
+    raw_system = arguments.get("system_id")
+    if not raw_system:
+        if required:
+            raise PretorianClientError("system_id is required")
+        return None
+    system_id, _ = await resolve_system(client, str(raw_system))
+    return system_id
 
 
 # =============================================================================
@@ -347,10 +374,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                 },
                 "required": ["system_id"],
             },
@@ -361,10 +385,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                 },
                 "required": ["system_id"],
             },
@@ -376,10 +397,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "Optional: search one system directly instead of org/global scope",
-                    },
+                    "system_id": _system_id_property(optional=True),
                     "control_id": _control_id_property(optional=True),
                     "framework_id": {
                         "type": "string",
@@ -403,10 +421,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "name": {
                         "type": "string",
                         "description": "Evidence name",
@@ -444,10 +459,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "evidence_id": {
                         "type": "string",
                         "description": "The evidence item ID",
@@ -468,14 +480,38 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
                         "description": "The framework ID (required for narrative lookup)",
+                    },
+                },
+                "required": ["system_id", "control_id", "framework_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_generate_control_artifacts",
+            description=(
+                "Generate read-only AI drafts for a control narrative and evidence-gap assessment "
+                "using the same Codex agent workflow as the CLI"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": _system_id_property(),
+                    "control_id": _control_id_property(),
+                    "framework_id": {
+                        "type": "string",
+                        "description": "The framework ID",
+                    },
+                    "working_directory": {
+                        "type": "string",
+                        "description": "Optional: local workspace path for code-aware drafting",
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": "Optional: model override for the Codex agent",
                     },
                 },
                 "required": ["system_id", "control_id", "framework_id"],
@@ -488,10 +524,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "title": {
                         "type": "string",
                         "description": "Event title",
@@ -527,10 +560,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
@@ -546,10 +576,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                 },
                 "required": ["system_id"],
             },
@@ -560,10 +587,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
@@ -594,10 +618,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
@@ -637,10 +658,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "status": {
                         "type": "string",
@@ -663,10 +681,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": {
-                        "type": "string",
-                        "description": "The system ID",
-                    },
+                    "system_id": _system_id_property(),
                     "control_id": _control_id_property(),
                     "framework_id": {
                         "type": "string",
@@ -912,7 +927,8 @@ async def _handle_get_system(
     arguments: dict[str, Any],
 ) -> list[TextContent]:
     """Handle the get_system tool."""
-    system_id = arguments.get("system_id", "")
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     system = await client.get_system(system_id)
     return _format_json(
         {
@@ -930,7 +946,8 @@ async def _handle_get_compliance_status(
     arguments: dict[str, Any],
 ) -> list[TextContent]:
     """Handle the get_compliance_status tool."""
-    system_id = arguments.get("system_id", "")
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     status = await client.get_system_compliance_status(system_id)
     return _format_json(status)
 
@@ -941,8 +958,9 @@ async def _handle_search_evidence(
 ) -> list[TextContent]:
     """Handle the search_evidence tool."""
     raw_control_id = arguments.get("control_id")
+    system_id = await _resolve_system_id(client, arguments, required=False)
     evidence = await client.search_evidence_with_fallback(
-        system_id=arguments.get("system_id"),
+        system_id=system_id,
         control_id=normalize_control_id(raw_control_id) if raw_control_id else None,
         framework_id=arguments.get("framework_id"),
         limit=arguments.get("limit", 20),
@@ -950,7 +968,7 @@ async def _handle_search_evidence(
     return _format_json(
         {
             "total": len(evidence),
-            "system_id": arguments.get("system_id"),
+            "system_id": system_id,
             "evidence": [
                 {
                     "id": e.id,
@@ -982,10 +1000,12 @@ async def _handle_create_evidence(
 
     dedupe = arguments.get("dedupe", True)
     raw_control_id = arguments.get("control_id")
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     try:
         result = await upsert_evidence(
             client,
-            system_id=arguments["system_id"],
+            system_id=system_id,
             name=arguments.get("name", ""),
             description=arguments.get("description", ""),
             evidence_type=evidence_type,
@@ -1013,7 +1033,7 @@ async def _handle_link_evidence(
     result = await client.link_evidence_to_control(
         evidence_id=arguments["evidence_id"],
         control_id=normalize_control_id(arguments["control_id"]),
-        system_id=arguments["system_id"],
+        system_id=await _resolve_system_id(client, arguments) or "",
         framework_id=arguments.get("framework_id"),
     )
     return _format_json(result)
@@ -1028,8 +1048,10 @@ async def _handle_get_narrative(
     if err:
         return _format_error(err)
 
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     narrative = await client.get_narrative(
-        system_id=arguments["system_id"],
+        system_id=system_id,
         control_id=normalize_control_id(arguments["control_id"]),
         framework_id=arguments["framework_id"],
     )
@@ -1037,11 +1059,32 @@ async def _handle_get_narrative(
         {
             "control_id": narrative.control_id,
             "framework_id": narrative.framework_id,
+            "system_id": system_id,
             "narrative": narrative.narrative,
             "ai_confidence_score": narrative.ai_confidence_score,
             "status": narrative.status,
         }
     )
+
+
+async def _handle_generate_control_artifacts(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle read-only AI drafting for control narratives and evidence gaps."""
+    err = _require(arguments, "system_id", "control_id", "framework_id")
+    if err:
+        return _format_error(err)
+
+    result = await draft_control_artifacts(
+        client,
+        system=arguments["system_id"],
+        framework_id=arguments["framework_id"],
+        control_id=arguments["control_id"],
+        working_directory=Path(arguments["working_directory"]) if arguments.get("working_directory") else None,
+        model=arguments.get("model"),
+    )
+    return _format_json(result)
 
 
 async def _handle_push_monitoring_event(
@@ -1065,6 +1108,8 @@ async def _handle_push_monitoring_event(
         return _format_error(enum_err)
 
     raw_control_id = arguments.get("control_id")
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     event = MonitoringEventCreate(
         event_type=event_type,
         title=arguments["title"],
@@ -1074,7 +1119,7 @@ async def _handle_push_monitoring_event(
         event_data={"source": "cli"},
     )
     result = await client.create_monitoring_event(
-        system_id=arguments["system_id"],
+        system_id=system_id,
         event=event,
     )
     return _format_json(result)
@@ -1085,8 +1130,10 @@ async def _handle_get_control_context(
     arguments: dict[str, Any],
 ) -> list[TextContent]:
     """Handle the get_control_context tool."""
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     ctx = await client.get_control_context(
-        system_id=arguments.get("system_id", ""),
+        system_id=system_id,
         control_id=normalize_control_id(arguments.get("control_id", "")),
         framework_id=arguments.get("framework_id", ""),
     )
@@ -1098,8 +1145,10 @@ async def _handle_get_scope(
     arguments: dict[str, Any],
 ) -> list[TextContent]:
     """Handle the get_scope tool."""
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     scope = await client.get_scope(
-        system_id=arguments.get("system_id", ""),
+        system_id=system_id,
     )
     return _format_json(scope.model_dump())
 
@@ -1113,8 +1162,10 @@ async def _handle_add_control_note(
     if err:
         return _format_error(err)
 
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     result = await client.add_control_note(
-        system_id=arguments["system_id"],
+        system_id=system_id,
         control_id=normalize_control_id(arguments["control_id"]),
         content=arguments["content"],
         framework_id=arguments["framework_id"],
@@ -1129,14 +1180,17 @@ async def _handle_get_control_notes(
 ) -> list[TextContent]:
     """Handle the get_control_notes tool."""
     normalized_control_id = normalize_control_id(arguments.get("control_id", ""))
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     notes = await client.list_control_notes(
-        system_id=arguments.get("system_id", ""),
+        system_id=system_id,
         control_id=normalized_control_id,
         framework_id=arguments.get("framework_id"),
     )
     return _format_json(
         {
             "control_id": normalized_control_id,
+            "system_id": system_id,
             "framework_id": arguments.get("framework_id"),
             "total": len(notes),
             "notes": notes,
@@ -1153,9 +1207,11 @@ async def _handle_update_narrative(
     if err:
         return _format_error(err)
 
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     try:
         result = await client.update_narrative(
-            system_id=arguments["system_id"],
+            system_id=system_id,
             control_id=normalize_control_id(arguments["control_id"]),
             framework_id=arguments["framework_id"],
             narrative=arguments["narrative"],
@@ -1179,8 +1235,10 @@ async def _handle_update_control_status(
     if enum_err:
         return _format_error(enum_err)
 
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     result = await client.update_control_status(
-        system_id=arguments["system_id"],
+        system_id=system_id,
         control_id=normalize_control_id(arguments["control_id"]),
         status=arguments["status"],
         framework_id=arguments.get("framework_id"),
@@ -1197,14 +1255,17 @@ async def _handle_get_control_implementation(
     if err:
         return _format_error(err)
 
+    system_id = await _resolve_system_id(client, arguments)
+    assert system_id is not None
     impl = await client.get_control_implementation(
-        system_id=arguments["system_id"],
+        system_id=system_id,
         control_id=normalize_control_id(arguments["control_id"]),
         framework_id=arguments["framework_id"],
     )
     return _format_json(
         {
             "control_id": impl.control_id,
+            "system_id": system_id,
             "status": impl.status,
             "narrative": impl.narrative,
             "evidence_count": impl.evidence_count,
@@ -1229,6 +1290,7 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "pretorin_create_evidence": _handle_create_evidence,
     "pretorin_link_evidence": _handle_link_evidence,
     "pretorin_get_narrative": _handle_get_narrative,
+    "pretorin_generate_control_artifacts": _handle_generate_control_artifacts,
     "pretorin_push_monitoring_event": _handle_push_monitoring_event,
     "pretorin_add_control_note": _handle_add_control_note,
     "pretorin_get_control_notes": _handle_get_control_notes,

--- a/src/pretorin/workflows/ai_generation.py
+++ b/src/pretorin/workflows/ai_generation.py
@@ -1,0 +1,143 @@
+"""Shared AI drafting workflows for compliance artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pretorin.client import PretorianClient
+from pretorin.client.api import PretorianClientError
+from pretorin.utils import normalize_control_id
+from pretorin.workflows.compliance_updates import resolve_system
+
+
+def _strip_json_fence(text: str) -> str:
+    """Remove optional fenced-code wrappers from agent JSON responses."""
+    stripped = text.strip()
+    if stripped.startswith("```json"):
+        stripped = stripped[7:]
+    elif stripped.startswith("```"):
+        stripped = stripped[3:]
+    if stripped.endswith("```"):
+        stripped = stripped[:-3]
+    return stripped.strip()
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Parse a JSON object from a model response, tolerating surrounding prose."""
+    candidate = _strip_json_fence(text)
+    try:
+        parsed = json.loads(candidate)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    start = candidate.find("{")
+    end = candidate.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        parsed = json.loads(candidate[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item is not None]
+
+
+def _dict_list(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    results: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        results.append({str(key): str(val) for key, val in item.items() if val is not None})
+    return results
+
+
+def _build_generation_task(system_id: str, system_name: str, framework_id: str, control_id: str) -> str:
+    """Create a tightly-scoped drafting task for the Codex agent."""
+    return (
+        f"Draft compliance artifacts for system {system_name} ({system_id}), "
+        f"framework {framework_id}, control {control_id}.\n\n"
+        "Use Pretorin tools first to read current control context, current narrative, evidence, and notes. "
+        "Do not write anything back to the platform. Return ONLY valid JSON with this exact shape:\n"
+        "{\n"
+        '  "narrative_draft": "<auditor-ready markdown>",\n'
+        '  "evidence_gap_assessment": "<auditor-ready markdown>",\n'
+        '  "recommended_notes": ["<canonical gap note>", "..."],\n'
+        '  "evidence_recommendations": [\n'
+        '    {"name": "<short title>", "evidence_type": "<policy_document|configuration|...>", '
+        '"description": "<auditor-ready markdown>"}\n'
+        "  ]\n"
+        "}\n\n"
+        "Requirements:\n"
+        "- Use only observable facts from Pretorin tools and mark unknowns explicitly.\n"
+        "- Use zero-padded control IDs (for example, ac-02).\n"
+        "- The narrative_draft must be auditor-ready markdown with no headings, at least two rich elements, "
+        "and at least one structural element.\n"
+        "- The evidence_gap_assessment must be auditor-ready markdown and include at least one table or list.\n"
+        "- If important narrative details are missing, include the exact [[PRETORIN_TODO]] block format.\n"
+        "- Each recommended note must use the exact Gap/Observed/Missing/Why missing/Manual next step format.\n"
+        "- Each evidence_recommendations.description must contain at least one rich markdown element and no headings."
+    )
+
+
+async def draft_control_artifacts(
+    client: PretorianClient,
+    *,
+    system: str,
+    framework_id: str,
+    control_id: str,
+    working_directory: Path | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Generate read-only narrative and evidence-gap drafts for a control."""
+    from pretorin.agent.codex_agent import CodexAgent
+
+    normalized_control_id = normalize_control_id(control_id)
+    system_id, system_name = await resolve_system(client, system)
+
+    try:
+        agent = CodexAgent(model=model)
+        result = await agent.run(
+            task=_build_generation_task(system_id, system_name, framework_id, normalized_control_id),
+            working_directory=working_directory,
+            skill="narrative-generation",
+            stream=False,
+        )
+    except RuntimeError as exc:
+        raise PretorianClientError(str(exc)) from exc
+
+    payload = _extract_json_object(result.response)
+    response: dict[str, Any] = {
+        "system_id": system_id,
+        "system_name": system_name,
+        "framework_id": framework_id,
+        "control_id": normalized_control_id,
+        "raw_response": result.response,
+        "parse_status": "raw_fallback",
+        "narrative_draft": None,
+        "evidence_gap_assessment": None,
+        "recommended_notes": [],
+        "evidence_recommendations": [],
+    }
+    if payload is None:
+        return response
+
+    response.update(
+        {
+            "parse_status": "json",
+            "narrative_draft": payload.get("narrative_draft"),
+            "evidence_gap_assessment": payload.get("evidence_gap_assessment"),
+            "recommended_notes": _string_list(payload.get("recommended_notes")),
+            "evidence_recommendations": _dict_list(payload.get("evidence_recommendations")),
+        }
+    )
+    return response

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -38,8 +38,9 @@ class TestToolListing:
             "pretorin_search_evidence",
             "pretorin_create_evidence",
             "pretorin_link_evidence",
-            # Narrative 1
+            # Narrative 2
             "pretorin_get_narrative",
+            "pretorin_generate_control_artifacts",
             # Notes 2
             "pretorin_add_control_note",
             "pretorin_get_control_notes",
@@ -54,7 +55,7 @@ class TestToolListing:
             "pretorin_get_control_implementation",
         ]
 
-        assert len(tools) == 22
+        assert len(tools) == 23
         for name in expected:
             assert name in tool_names, f"Missing tool: {name}"
 
@@ -95,6 +96,7 @@ def _make_mock_client(**overrides: Any) -> AsyncMock:
     """Create a properly configured mock PretorianClient."""
     client = AsyncMock()
     client.is_configured = True
+    client.list_systems = AsyncMock(return_value=[{"id": "sys-1", "name": "Test System"}])
     for attr, val in overrides.items():
         setattr(client, attr, AsyncMock(return_value=val))
     return client
@@ -146,6 +148,20 @@ class TestSystemTools:
         assert data["id"] == "sys-1"
         assert data["name"] == "Test System"
 
+    def test_get_system_resolves_system_name(self) -> None:
+        from pretorin.client.models import SystemDetail
+
+        system = SystemDetail(
+            id="sys-1",
+            name="Test System",
+            description="Desc",
+            frameworks=[{"id": "fedramp-moderate"}],
+            security_impact_level="moderate",
+        )
+        client = _make_mock_client(get_system=system)
+        _run_tool("pretorin_get_system", {"system_id": "test"}, client)
+        client.get_system.assert_awaited_once_with("sys-1")
+
     def test_get_compliance_status(self) -> None:
         status_data = {"system_id": "sys-1", "frameworks": [{"id": "fedramp-moderate", "progress": 75}]}
         client = _make_mock_client(get_system_compliance_status=status_data)
@@ -183,6 +199,16 @@ class TestEvidenceTools:
     def test_search_evidence_accepts_system_id(self) -> None:
         client = _make_mock_client(search_evidence_with_fallback=[])
         _run_tool("pretorin_search_evidence", {"system_id": "sys-1", "control_id": "ac-2"}, client)
+        client.search_evidence_with_fallback.assert_awaited_once_with(
+            system_id="sys-1",
+            control_id="ac-02",
+            framework_id=None,
+            limit=20,
+        )
+
+    def test_search_evidence_resolves_system_name(self) -> None:
+        client = _make_mock_client(search_evidence_with_fallback=[])
+        _run_tool("pretorin_search_evidence", {"system_id": "test", "control_id": "ac-2"}, client)
         client.search_evidence_with_fallback.assert_awaited_once_with(
             system_id="sys-1",
             control_id="ac-02",
@@ -303,6 +329,67 @@ class TestNarrativeTools:
         result = _run_tool("pretorin_get_narrative", {"system_id": "sys-1", "control_id": "ac-2"}, client)
         assert result.isError is True
         assert any("Missing required" in c.text for c in result.content)
+
+    def test_get_narrative_resolves_system_name(self) -> None:
+        from pretorin.client.models import NarrativeResponse
+
+        narrative = NarrativeResponse(
+            control_id="ac-2",
+            framework_id="fedramp-moderate",
+            narrative="Existing narrative",
+            ai_confidence_score=0.9,
+            status="approved",
+        )
+        client = _make_mock_client(get_narrative=narrative)
+        _run_tool(
+            "pretorin_get_narrative",
+            {
+                "system_id": "test",
+                "control_id": "ac-2",
+                "framework_id": "fedramp-moderate",
+            },
+            client,
+        )
+        client.get_narrative.assert_awaited_once_with(
+            system_id="sys-1",
+            control_id="ac-02",
+            framework_id="fedramp-moderate",
+        )
+
+    def test_generate_control_artifacts(self) -> None:
+        client = _make_mock_client()
+        with patch(
+            "pretorin.mcp.server.draft_control_artifacts",
+            new=AsyncMock(
+                return_value={
+                    "system_id": "sys-1",
+                    "system_name": "Test System",
+                    "framework_id": "fedramp-moderate",
+                    "control_id": "ac-02",
+                    "parse_status": "json",
+                    "narrative_draft": "- Draft narrative",
+                    "evidence_gap_assessment": "| Gap | Detail |",
+                    "recommended_notes": ["Gap: Missing review"],
+                    "evidence_recommendations": [{"name": "IAM Export", "evidence_type": "configuration"}],
+                    "raw_response": "{}",
+                }
+            ),
+        ) as mock_generate:
+            result = _run_tool(
+                "pretorin_generate_control_artifacts",
+                {
+                    "system_id": "test",
+                    "control_id": "ac-2",
+                    "framework_id": "fedramp-moderate",
+                },
+                client,
+            )
+
+        data = _parse_result(result)
+        assert data["control_id"] == "ac-02"
+        assert data["parse_status"] == "json"
+        assert data["narrative_draft"] == "- Draft narrative"
+        mock_generate.assert_awaited_once()
 
     def test_get_control_notes(self) -> None:
         client = _make_mock_client(
@@ -439,7 +526,7 @@ class TestErrorHandling:
         assert result.isError is True
         text = result.content[0].text
         assert "Error" in text
-        assert "Not found" in text
+        assert "System not found: bad-id" in text
 
     def test_api_error_returns_error(self) -> None:
         client = _make_mock_client()

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "pretorin"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add MCP system-name resolution so MCP handlers accept friendly system names like the CLI
- add read-only MCP control artifact drafting via the same Codex workflow used by the CLI
- bump the package version and changelog to 0.8.0

## Verification
- uv run pytest tests/test_mcp_tools_expanded.py tests/test_agent_cli.py tests/test_control_id_normalization.py tests/test_compliance_cli_commands.py
- uv run mypy src/pretorin
- uv run ruff check src/pretorin tests
- live smoke tests for MCP name resolution and pretorin_generate_control_artifacts after pinning Codex MCP config to the UV-managed pretorin wrapper