### PR TITLE
fix(cli): release post-smoke hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 Pretorin CLI gives developers and AI agents direct access to compliance data, implementation context, and evidence workflows.
 
+`mcp-name: io.github.pretorin-ai/pretorin`
+
 ## Two Usage Modes
 
 1. Pretorin-hosted model mode: run `pretorin agent run` and route model calls through Pretorin `/v1` endpoints.


### PR DESCRIPTION
## Summary
- fix prod login/config handling so API and model endpoints stay aligned
- clear stale active scope context when API identity changes
- make `scope populate --json --apply` and `policy populate --json --apply` actually persist updates
- increase the Codex subprocess buffer for larger questionnaire responses
- bump the package to `0.8.5`

## Testing
- uv run pytest tests/test_scope_policy_cli.py tests/test_client_auth_coverage.py tests/test_codex_agent.py tests/test_cli_main_coverage.py tests/test_version_check_coverage.py
- uv run ruff check src/pretorin/client/auth.py src/pretorin/cli/scope.py src/pretorin/cli/policy.py src/pretorin/agent/codex_agent.py tests/test_client_auth_coverage.py tests/test_scope_policy_cli.py
