### PR TITLE
fix(context): validate stored scope and cut 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Pretorin CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2026-03-23
+
+### Added
+- `pretorin context show --quiet` for a compact one-line context summary that works well in scripts and shell prompts
+- `pretorin context show --check` to fail fast when the stored system/framework scope is missing, stale, or cannot be verified
+
+### Changed
+- `context show` now caches and displays the last known system name so offline or stale context output stays human-friendly instead of falling back to a raw UUID
+
+### Fixed
+- `context show` now validates stored context against the platform and clearly reports invalid or unverified scope instead of silently treating deleted systems as active
+
 ## [0.8.5] - 2026-03-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ command = "pretorin"
 args = ["mcp-serve"]
 ```
 
+If you installed Pretorin with `uv tool install` or `pipx`, prefer pinning the absolute path from `command -v pretorin` to avoid PATH drift between shells and GUI apps.
+
 For Claude Desktop, Cursor, and Windsurf setup, see [docs/MCP.md](docs/MCP.md).
 
 ## Core Commands
@@ -122,6 +124,8 @@ Platform-backed review and update workflows are single-scope: set one active `sy
 | `pretorin frameworks list` | List available frameworks |
 | `pretorin frameworks control <framework> <control>` | Get control details and guidance |
 | `pretorin context set` | Set active system/framework context |
+| `pretorin context show` | Inspect and validate the active context |
+| `pretorin context clear` | Clear the active context |
 | `pretorin evidence create` | Create local evidence file |
 | `pretorin evidence list` | List local evidence files |
 | `pretorin evidence push` | Push local evidence to Pretorin |
@@ -141,6 +145,15 @@ Platform-backed review and update workflows are single-scope: set one active `sy
 | `pretorin agent run "<task>"` | Run Codex-powered compliance task |
 | `pretorin review run --control-id <id> --path <dir>` | Review local code for control coverage |
 | `pretorin mcp-serve` | Start MCP server |
+
+Quick context checks:
+
+```bash
+pretorin context show --quiet
+pretorin context show --quiet --check
+```
+
+`pretorin login` clears the stored active context when you switch API keys or platform endpoints, which helps prevent old localhost or deleted-system scope from leaking into a new environment.
 
 ## Artifact Authoring Rules
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -326,6 +326,8 @@ pretorin context set
 pretorin context set --system "My Application" --framework nist-800-53-r5
 ```
 
+Pretorin stores the canonical system ID for stability and also caches the last known system name for display. If you switch API keys or platform endpoints with `pretorin login`, the stored active context is cleared automatically so old scope does not leak into the new environment.
+
 Platform-backed compliance execution is single-scope. Commands that create or update evidence, notes, monitoring events, narratives, or control state operate within exactly one active `system + framework` pair. If you need to work across `fedramp-low` and `fedramp-moderate`, run them separately.
 
 ### Show Current Context
@@ -333,11 +335,20 @@ Platform-backed compliance execution is single-scope. Commands that create or up
 ```bash
 $ pretorin context show
 ╭──────────────────────── Active Context ─────────────────────────╮
-│ System: My Application                                          │
-│ Framework: NIST SP 800-53 Rev 5                                │
-│ Progress: 42% (136/324 implemented, 45 in progress)            │
+│ System: My Application (sys-1234...)                           │
+│ Framework: nist-800-53-r5                                      │
+│ Progress: 42%                                                  │
+│ Status: in_progress                                            │
 ╰─────────────────────────────────────────────────────────────────╯
+
+# Compact summary for shell use
+pretorin context show --quiet
+
+# Exit non-zero if stored context is missing, stale, or cannot be verified
+pretorin context show --quiet --check
 ```
+
+`context show` validates stored scope against the platform when credentials are available and reports invalid or unverified context explicitly instead of silently showing deleted systems as active.
 
 ### Clear Context
 
@@ -678,7 +689,7 @@ Different frameworks use different ID conventions. Always use `pretorin framewor
 | `pretorin frameworks submit-artifact <file>` | Submit a compliance artifact JSON file |
 | `pretorin context list` | List systems and frameworks with progress |
 | `pretorin context set` | Set active system/framework context |
-| `pretorin context show` | Display current active context |
+| `pretorin context show` | Display and validate current active context |
 | `pretorin context clear` | Clear active context |
 | `pretorin evidence create` | Create a local evidence file |
 | `pretorin evidence list` | List local evidence files |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,6 +4,12 @@ The Pretorin CLI includes a built-in MCP server that enables AI assistants like 
 
 Scoped compliance execution tools on the MCP server run inside exactly one `system + framework` pair at a time. Set the active scope with `pretorin context set`, or pass both values explicitly. If a request spans multiple framework levels or systems, split it into separate runs.
 
+Before running write-heavy MCP workflows from a shell or GUI wrapper, prefer validating the stored scope with:
+
+```bash
+pretorin context show --quiet --check
+```
+
 ## Why MCP?
 
 The Model Context Protocol allows AI assistants to:
@@ -321,7 +327,7 @@ Get framework progress and implementation posture for a system.
 Get rich context for a control including AI guidance, control statement, assessment objectives, scope status, and current implementation details.
 
 **Parameters:**
-- `system_id` (required): The system ID
+- `system_id` (required): The system ID or name
 - `control_id` (required): The control ID (zero-padded for NIST/FedRAMP, e.g., `ac-01`)
 - `framework_id` (required): The framework ID
 
@@ -336,7 +342,7 @@ Get rich context for a control including AI guidance, control statement, assessm
 Get the current narrative record for a control.
 
 **Parameters:**
-- `system_id` (required): The system ID
+- `system_id` (required): The system ID or name
 - `control_id` (required): The control ID
 - `framework_id` (required): The framework ID
 
@@ -351,7 +357,7 @@ Get the current narrative record for a control.
 Get system scope and policy information including excluded controls and Q&A responses.
 
 **Parameters:**
-- `system_id` (required): The system ID
+- `system_id` (required): The system ID or name
 
 **Returns:** Scope narrative, list of excluded controls, Q&A responses, and scope status.
 
@@ -588,6 +594,13 @@ pretorin whoami  # Verify authentication
    ```bash
    command -v pretorin
    ```
+
+4. If the MCP client can connect but scoped write tools behave strangely, validate the stored CLI context:
+   ```bash
+   pretorin context show --quiet --check
+   ```
+
+   This catches deleted systems, detached frameworks, and other stale local scope before you debug the MCP client itself.
 
 ### Server Crashes or Hangs
 

--- a/docs/src/cli/command-reference.md
+++ b/docs/src/cli/command-reference.md
@@ -38,7 +38,7 @@
 |---------|-------------|
 | `pretorin context list` | List systems and frameworks with progress |
 | `pretorin context set` | Set active system/framework context (`--system`, `--framework`) |
-| `pretorin context show` | Display current active context |
+| `pretorin context show` | Display and validate current active context (`--quiet`, `--check`) |
 | `pretorin context clear` | Clear active context |
 
 ## Evidence Commands

--- a/docs/src/cli/context.md
+++ b/docs/src/cli/context.md
@@ -29,16 +29,27 @@ pretorin context set
 pretorin context set --system "My Application" --framework nist-800-53-r5
 ```
 
+Pretorin stores the canonical system ID for stability and also caches the last known system name for display. If you change API keys or platform endpoints with `pretorin login`, the stored active context is cleared automatically so old scope does not leak into the new environment.
+
 ## Show Current Context
 
 ```bash
 $ pretorin context show
 ╭──────────────────────── Active Context ─────────────────────────╮
-│ System: My Application                                          │
-│ Framework: NIST SP 800-53 Rev 5                                │
-│ Progress: 42% (136/324 implemented, 45 in progress)            │
+│ System: My Application (sys-1234...)                           │
+│ Framework: nist-800-53-r5                                      │
+│ Progress: 42%                                                  │
+│ Status: in_progress                                            │
 ╰─────────────────────────────────────────────────────────────────╯
+
+# Compact summary for shell use
+pretorin context show --quiet
+
+# Fail fast if the stored context is missing, stale, or cannot be verified
+pretorin context show --quiet --check
 ```
+
+`context show` validates the stored system and framework against the platform when credentials are available. If the system has been deleted or the framework is no longer attached, the command reports that state explicitly instead of silently showing a stale context.
 
 ## Clear Context
 

--- a/docs/src/getting-started/authentication.md
+++ b/docs/src/getting-started/authentication.md
@@ -16,6 +16,8 @@ You'll be prompted to enter your API key. Credentials are stored in `~/.pretorin
 
 If you're already authenticated, `pretorin login` validates your existing key against the API and skips the prompt.
 
+If you log into a different API endpoint or switch API keys, Pretorin clears the stored active `system + framework` context so stale scope does not bleed into the new environment.
+
 ## Verify Authentication
 
 ```bash

--- a/docs/src/mcp/overview.md
+++ b/docs/src/mcp/overview.md
@@ -28,6 +28,12 @@ The MCP server communicates via stdio (standard input/output) using JSON-RPC mes
 
 Scoped compliance execution tools on the MCP server run inside exactly one `system + framework` pair at a time. Set the active scope with `pretorin context set`, or pass both values explicitly. If a request spans multiple frameworks or systems, split it into separate runs.
 
+Before running write-heavy MCP workflows from a shell or GUI wrapper, prefer validating the stored scope with:
+
+```bash
+pretorin context show --quiet --check
+```
+
 ## Tool Categories
 
 The 23 MCP tools are organized into categories:

--- a/docs/src/mcp/setup.md
+++ b/docs/src/mcp/setup.md
@@ -137,3 +137,9 @@ Then use that path in your configuration:
 ```
 
 This is especially important for `uv tool` and `pipx` installations where the binary may not be on the PATH available to GUI applications.
+
+Before debugging scoped MCP write failures, validate the active CLI scope:
+
+```bash
+pretorin context show --quiet --check
+```

--- a/docs/src/mcp/tools.md
+++ b/docs/src/mcp/tools.md
@@ -113,7 +113,7 @@ Get system metadata including attached frameworks and security impact level.
 Get framework progress and implementation posture for a system.
 
 **Parameters:**
-- `system_id` (required)
+- `system_id` (required) — System ID or friendly system name
 
 **Returns:** Framework status summaries and progress metrics.
 
@@ -126,11 +126,11 @@ Get framework progress and implementation posture for a system.
 Search current evidence items.
 
 **Parameters:**
-- `system_id` (optional) — System context
+- `system_id` (optional) — System ID or friendly system name. When omitted, the active CLI scope is used if available.
 - `control_id` (optional) — Filter by control
 - `framework_id` (optional) — Filter by framework
 
-**Returns:** Matching evidence items.
+**Returns:** Matching evidence items. The server uses the same compatibility search path as the CLI for deployments that only expose system-scoped evidence routes.
 
 ---
 

--- a/docs/src/mcp/troubleshooting.md
+++ b/docs/src/mcp/troubleshooting.md
@@ -37,6 +37,14 @@ pretorin whoami  # Verify authentication
    command -v pretorin
    ```
 
+4. If the MCP client can talk to Pretorin but scoped write tools behave strangely, validate the stored CLI context:
+
+   ```bash
+   pretorin context show --quiet --check
+   ```
+
+   This catches deleted systems, detached frameworks, and other stale local scope before you debug the MCP client itself.
+
 ## Server Crashes or Hangs
 
 Check the MCP server logs:

--- a/docs/src/reference/changelog.md
+++ b/docs/src/reference/changelog.md
@@ -2,6 +2,26 @@
 
 All notable changes to the Pretorin CLI are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2026-03-23
+
+### Added
+- `pretorin context show --quiet` for compact shell-friendly context checks
+- `pretorin context show --check` to fail fast when stored scope is missing, stale, or unverified
+
+### Changed
+- `context show` caches the last known system name so offline and stale context output stays human-friendly
+
+### Fixed
+- `context show` validates stored context against the platform instead of silently treating deleted systems as active
+
+## [0.8.5] - 2026-03-23
+
+### Fixed
+- Reset active system/framework context when logging into a different API endpoint or with a different API key
+- Model API base URL now follows the configured platform public API endpoint during login
+- `scope populate --json --apply` and `policy populate --json --apply` now persist questionnaire updates
+- Larger Codex subprocess line buffer for policy questionnaire responses
+
 ## [0.8.0] - 2026-03-07
 
 ### Added
@@ -146,6 +166,8 @@ All notable changes to the Pretorin CLI are documented here. The format is based
 - FedRAMP (Low, Moderate, High)
 - CMMC Level 1, 2, and 3
 
+[0.8.6]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.5...v0.8.6
+[0.8.5]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.0...v0.8.5
 [0.8.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.6.0...v0.6.1

--- a/pretorin-skill/SKILL.md
+++ b/pretorin-skill/SKILL.md
@@ -8,7 +8,7 @@ description: >
   are needed for certification. Trigger phrases include "list frameworks",
   "show controls", "what documents do I need", "compliance check",
   "control requirements", "gap analysis", and "audit my code".
-version: 0.8.0
+version: 0.8.6
 ---
 
 # Pretorin Compliance Skill
@@ -24,6 +24,8 @@ uv tool install pretorin
 pretorin login
 claude mcp add --transport stdio pretorin -- pretorin mcp-serve
 ```
+
+When the user says "my current system" or relies on stored CLI scope, suggest `pretorin context show --quiet --check` before assuming the local context is still valid.
 
 ## Available Frameworks
 
@@ -67,8 +69,8 @@ When unsure of an ID, discover it first with `pretorin_list_control_families` or
 
 ### Systems
 - **`pretorin_list_systems`** — List systems in the organization. Start here when the user has not identified a target system.
-- **`pretorin_get_system`** — Get system metadata including attached frameworks and security impact level. Pass `system_id`.
-- **`pretorin_get_compliance_status`** — Get framework progress and implementation posture for a system. Pass `system_id`.
+- **`pretorin_get_system`** — Get system metadata including attached frameworks and security impact level. Pass a canonical `system_id` or a friendly system name.
+- **`pretorin_get_compliance_status`** — Get framework progress and implementation posture for a system. Pass a canonical `system_id` or a friendly system name.
 
 ### System & Implementation Context
 - **`pretorin_get_control_context`** — Get rich context for a control including AI guidance, statement, objectives, scope status, and current implementation details. Pass `system_id`, `control_id`, and `framework_id`. This is the most comprehensive view for understanding both what a control requires and how it's currently implemented.
@@ -80,6 +82,9 @@ When unsure of an ID, discover it first with `pretorin_list_control_families` or
 - **`pretorin_create_evidence`** — Upsert evidence (find-or-create by default with `dedupe: true`) and return whether it was created or reused. Pass `system_id`, `name`, `description`, `evidence_type`, and control/framework context.
 - **`pretorin_link_evidence`** — Link an existing evidence item to a control (low-level helper).
 - **`pretorin_add_control_note`** — Add a note for unresolved gaps or manual follow-up actions.
+
+### Evidence Search
+- **`pretorin_search_evidence`** — Search evidence inside the active or explicit system/framework scope. Pass `system_id` when you want to override the active scope; friendly system names are accepted.
 
 ### Review, Monitoring, and Drafting
 - **`pretorin_generate_control_artifacts`** — Generate read-only AI drafts for a control narrative and evidence-gap assessment using the same Codex workflow as the CLI. Use this when the user wants a draft without writing to the platform yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.8.5"
+version = "0.8.6"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"

--- a/src/pretorin/cli/context.py
+++ b/src/pretorin/cli/context.py
@@ -52,6 +52,90 @@ def _ensure_single_framework_scope(framework_id: str) -> str:
     return candidate
 
 
+def _build_context_payload(
+    *,
+    system_id: str | None,
+    framework_id: str | None,
+    system_name: str | None = None,
+    progress: int = 0,
+    status: str = "unknown",
+    valid: bool | None = None,
+    validation_state: str = "unverified",
+    validation_error: str | None = None,
+) -> dict[str, Any]:
+    """Create a consistent payload for context display and JSON output."""
+    return {
+        "active_system_id": system_id,
+        "active_system_name": system_name or system_id,
+        "active_framework_id": framework_id,
+        "progress": progress,
+        "status": status,
+        "valid": valid,
+        "validation_state": validation_state,
+        "validation_error": validation_error,
+    }
+
+
+def _format_context_subject(payload: dict[str, Any]) -> str:
+    """Return a compact human-readable system label."""
+    system_id = payload.get("active_system_id")
+    system_name = payload.get("active_system_name")
+    if system_name and system_id and system_name != system_id:
+        return f"{system_name} ({system_id})"
+    return system_name or system_id or "-"
+
+
+def _format_quiet_context(payload: dict[str, Any]) -> str:
+    """Render a single-line context summary."""
+    subject = _format_context_subject(payload)
+    framework_id = payload.get("active_framework_id") or "-"
+    validation_state = payload.get("validation_state")
+    validation_error = payload.get("validation_error")
+    if validation_state == "valid":
+        return f"{subject} / {framework_id} [{payload.get('status', 'unknown')}, {payload.get('progress', 0)}%]"
+    if validation_state == "invalid" and validation_error:
+        return f"{subject} / {framework_id} [invalid: {validation_error}]"
+    if validation_error:
+        return f"{subject} / {framework_id} [unverified: {validation_error}]"
+    return f"{subject} / {framework_id}"
+
+
+def _show_context_payload(payload: dict[str, Any], *, quiet: bool = False) -> None:
+    """Render context payload in JSON, compact, or panel form."""
+    if is_json_mode():
+        print_json(payload)
+        return
+
+    validation_state = payload.get("validation_state")
+    validation_error = payload.get("validation_error")
+    if quiet:
+        console.print(_format_quiet_context(payload), markup=False)
+        return
+
+    status_line = (
+        f"  [bold]System:[/bold]    {_format_context_subject(payload)}\n"
+        f"  [bold]Framework:[/bold] {payload.get('active_framework_id')}\n"
+        f"  [bold]Progress:[/bold]  {payload.get('progress', 0)}%\n"
+        f"  [bold]Status:[/bold]    {payload.get('status', 'unknown')}"
+    )
+    if validation_state == "invalid" and validation_error:
+        status_line += f"\n  [bold]Validation:[/bold] invalid\n  [bold]Note:[/bold]      {validation_error}"
+    elif validation_error:
+        status_line += f"\n  [bold]Validation:[/bold] {validation_state}\n  [bold]Note:[/bold]      {validation_error}"
+
+    border_style = "#95D7E0" if validation_state == "valid" else "#EAB536"
+    title_bot = ROMEBOT_HAPPY if validation_state == "valid" else ROMEBOT_THINKING
+    rprint()
+    rprint(
+        Panel(
+            status_line,
+            title=f"{title_bot}  Active Context",
+            border_style=border_style,
+            padding=(1, 2),
+        )
+    )
+
+
 async def resolve_execution_context(
     client: Any,
     *,
@@ -348,6 +432,7 @@ async def _context_set(
         # --- Save context ---
         config = Config()
         config.set("active_system_id", system_id)
+        config.set("active_system_name", system_name)
         config.set("active_framework_id", target_framework_id)
 
         if is_json_mode():
@@ -372,90 +457,129 @@ async def _context_set(
 
 
 @app.command("show")
-def context_show() -> None:
+def context_show(
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Show a compact one-line summary instead of the rich panel.",
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Exit non-zero when the stored context is missing, stale, or cannot be verified.",
+    ),
+) -> None:
     """Show the currently active system and framework context."""
-    asyncio.run(_context_show())
+    asyncio.run(_context_show(quiet=quiet, check=check))
 
 
-async def _context_show() -> None:
+async def _context_show(*, quiet: bool = False, check: bool = False) -> None:
     """Display the current context with live status."""
     from pretorin.client.api import PretorianClient, PretorianClientError
     from pretorin.client.config import Config
 
     config = Config()
     system_id = config.get("active_system_id")
+    cached_system_name = config.get("active_system_name")
     framework_id = config.get("active_framework_id")
 
     if not system_id or not framework_id:
+        payload = _build_context_payload(
+            system_id=system_id,
+            framework_id=framework_id,
+            system_name=cached_system_name,
+            valid=False,
+            validation_state="invalid",
+            validation_error="No active context set.",
+        )
         if is_json_mode():
-            print_json({"active_system_id": None, "active_framework_id": None})
+            print_json(payload)
+        elif quiet:
+            rprint("no active context")
         else:
             rprint(f"\n  {ROMEBOT_SAD}  No active context set.\n")
             rprint("  Run [bold]pretorin context set[/bold] to select a system and framework.")
+        if check:
+            raise typer.Exit(1)
         return
 
     async with PretorianClient() as client:
         if not client.is_configured:
-            # Show stored context even without API access
-            if is_json_mode():
-                print_json({"active_system_id": system_id, "active_framework_id": framework_id})
-            else:
-                rprint(
-                    Panel(
-                        f"  [bold]System ID:[/bold]  {system_id}\n"
-                        f"  [bold]Framework:[/bold]  {framework_id}\n\n"
-                        "  [dim]Not logged in — showing stored context only.[/dim]",
-                        title=f"{ROMEBOT_THINKING}  Active Context",
-                        border_style="#EAB536",
-                        padding=(1, 2),
-                    )
-                )
+            payload = _build_context_payload(
+                system_id=system_id,
+                framework_id=framework_id,
+                system_name=cached_system_name,
+                valid=None,
+                validation_state="unverified",
+                validation_error="Not logged in — showing stored context only.",
+            )
+            _show_context_payload(payload, quiet=quiet)
+            if check:
+                raise typer.Exit(1)
             return
 
-        # Fetch live info
-        system_name = system_id
-        progress = 0
-        status = "unknown"
+        payload = _build_context_payload(
+            system_id=system_id,
+            framework_id=framework_id,
+            system_name=cached_system_name,
+            valid=None,
+            validation_state="unverified",
+        )
 
         try:
-            sys_detail = await client.get_system(system_id)
-            system_name = sys_detail.name
-        except PretorianClientError:
-            pass
+            systems = await client.list_systems()
+        except PretorianClientError as e:
+            payload["validation_error"] = f"Could not validate stored context: {e.message}"
+            _show_context_payload(payload, quiet=quiet)
+            if check:
+                raise typer.Exit(1)
+            return
+
+        matched_system = next((item for item in systems if item.get("id") == system_id), None)
+        if not matched_system:
+            payload["valid"] = False
+            payload["validation_state"] = "invalid"
+            payload["validation_error"] = f"Stored system '{system_id}' no longer exists on the platform."
+            _show_context_payload(payload, quiet=quiet)
+            if check:
+                raise typer.Exit(1)
+            return
+
+        payload["active_system_name"] = matched_system.get("name", system_id)
 
         try:
             compliance = await client.get_system_compliance_status(system_id)
-            for fw in compliance.get("frameworks", []):
-                if fw.get("framework_id") == framework_id:
-                    progress = fw.get("progress", 0)
-                    status = fw.get("status", "unknown")
-                    break
-        except PretorianClientError:
-            pass
+        except PretorianClientError as e:
+            payload["validation_error"] = f"Could not validate framework membership: {e.message}"
+            _show_context_payload(payload, quiet=quiet)
+            if check:
+                raise typer.Exit(1)
+            return
 
-        if is_json_mode():
-            print_json(
-                {
-                    "active_system_id": system_id,
-                    "active_system_name": system_name,
-                    "active_framework_id": framework_id,
-                    "progress": progress,
-                    "status": status,
-                }
-            )
-        else:
-            rprint()
-            rprint(
-                Panel(
-                    f"  [bold]System:[/bold]    {system_name} ({system_id[:8]}...)\n"
-                    f"  [bold]Framework:[/bold] {framework_id}\n"
-                    f"  [bold]Progress:[/bold]  {progress}%\n"
-                    f"  [bold]Status:[/bold]    {status}",
-                    title=f"{ROMEBOT_HAPPY}  Active Context",
-                    border_style="#95D7E0",
-                    padding=(1, 2),
+        frameworks = [fw for fw in compliance.get("frameworks", []) if fw.get("framework_id")]
+        matched_framework = next((fw for fw in frameworks if fw.get("framework_id") == framework_id), None)
+        if not matched_framework:
+            payload["valid"] = False
+            payload["validation_state"] = "invalid"
+            if frameworks:
+                available_frameworks = ", ".join(sorted(fw["framework_id"] for fw in frameworks))
+                payload["validation_error"] = (
+                    f"Framework '{framework_id}' is not associated with system "
+                    f"'{payload['active_system_name']}'. Available frameworks: {available_frameworks}"
                 )
-            )
+            else:
+                payload["validation_error"] = f"System '{payload['active_system_name']}' has no configured frameworks."
+            _show_context_payload(payload, quiet=quiet)
+            if check:
+                raise typer.Exit(1)
+            return
+
+        payload["valid"] = True
+        payload["validation_state"] = "valid"
+        payload["progress"] = matched_framework.get("progress", 0)
+        payload["status"] = matched_framework.get("status", "unknown")
+        _show_context_payload(payload, quiet=quiet)
 
 
 @app.command("clear")
@@ -465,6 +589,7 @@ def context_clear() -> None:
 
     config = Config()
     config.delete("active_system_id")
+    config.delete("active_system_name")
     config.delete("active_framework_id")
 
     if is_json_mode():

--- a/src/pretorin/client/config.py
+++ b/src/pretorin/client/config.py
@@ -171,8 +171,22 @@ class Config:
         """Set the active system ID."""
         if value is None:
             self.delete("active_system_id")
+            self.delete("active_system_name")
         else:
             self.set("active_system_id", value)
+
+    @property
+    def active_system_name(self) -> str | None:
+        """Get the cached active system name for friendlier context output."""
+        return self.get("active_system_name")
+
+    @active_system_name.setter
+    def active_system_name(self, value: str | None) -> None:
+        """Set the cached active system name."""
+        if value is None:
+            self.delete("active_system_name")
+        else:
+            self.set("active_system_name", value)
 
     @property
     def active_framework_id(self) -> str | None:

--- a/tests/test_cli_context_coverage.py
+++ b/tests/test_cli_context_coverage.py
@@ -130,6 +130,7 @@ def test_context_set_flags_json_mode():
     assert payload["system_id"] == "sys-1"
     assert payload["framework_id"] == "fedramp-moderate"
     mock_config.set.assert_any_call("active_system_id", "sys-1")
+    mock_config.set.assert_any_call("active_system_name", "Primary")
 
 
 def test_context_set_invalid_system_name_exits_one():
@@ -168,6 +169,7 @@ def test_context_set_interactive_mode_valid_selection(monkeypatch):
     assert result.exit_code == 0
     assert "Context Set" in result.output
     mock_config.set.assert_any_call("active_system_id", "sys-1")
+    mock_config.set.assert_any_call("active_system_name", "Primary")
     mock_config.set.assert_any_call("active_framework_id", "fedramp-moderate")
 
 
@@ -178,6 +180,7 @@ def test_context_set_interactive_mode_valid_selection(monkeypatch):
 
 def test_context_show_with_context_set_json_mode():
     client = _make_client(
+        systems=[{"id": "sys-1", "name": "Primary"}],
         compliance_status={"frameworks": [
             {"framework_id": "fedramp-moderate", "progress": 80, "status": "implemented"}
         ]}
@@ -193,6 +196,7 @@ def test_context_show_with_context_set_json_mode():
     payload = json.loads(result.stdout)
     assert payload["active_system_id"] == "sys-1"
     assert payload["active_framework_id"] == "fedramp-moderate"
+    assert payload["valid"] is True
 
 
 def test_context_show_not_logged_in_shows_stored_context():
@@ -200,6 +204,7 @@ def test_context_show_not_logged_in_shows_stored_context():
     mock_config = MagicMock()
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-offline",
+        "active_system_name": "Offline System",
         "active_framework_id": "fedramp-low",
     }.get(key)
     with patch("pretorin.client.config.Config", return_value=mock_config):
@@ -207,6 +212,7 @@ def test_context_show_not_logged_in_shows_stored_context():
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["active_system_id"] == "sys-offline"
+    assert payload["active_system_name"] == "Offline System"
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +228,7 @@ def test_context_clear_json_mode():
     payload = json.loads(result.stdout)
     assert payload["cleared"] is True
     mock_config.delete.assert_any_call("active_system_id")
+    mock_config.delete.assert_any_call("active_system_name")
     mock_config.delete.assert_any_call("active_framework_id")
 
 

--- a/tests/test_cli_context_coverage2.py
+++ b/tests/test_cli_context_coverage2.py
@@ -477,6 +477,7 @@ def test_context_show_no_context_json_mode():
     payload = json.loads(result.stdout)
     assert payload["active_system_id"] is None
     assert payload["active_framework_id"] is None
+    assert payload["valid"] is False
 
 
 def test_context_show_no_context_normal_mode():
@@ -501,51 +502,54 @@ def test_context_show_not_configured_non_json():
     mock_config = MagicMock()
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-offline",
+        "active_system_name": "Offline System",
         "active_framework_id": "fedramp-low",
     }.get(key)
     with patch("pretorin.client.config.Config", return_value=mock_config):
         result = _run_with_mock_client(["context", "show"], client)
     assert result.exit_code == 0
     assert "Active Context" in result.output
+    assert "Offline System (sys-offline)" in result.output
     assert "stored context only" in result.output
 
 
 # ---------------------------------------------------------------------------
-# _context_show — lines 423-424 (get_system PretorianClientError)
+# _context_show — stale or unverified context paths
 # ---------------------------------------------------------------------------
 
 
-def test_context_show_get_system_error_uses_system_id_as_name():
-    """Lines 423-424: system_name falls back to system_id when get_system fails."""
+def test_context_show_marks_missing_system_as_invalid():
+    """Stored context should be marked invalid when the system no longer exists."""
     client = _make_client(
+        systems=[{"id": "sys-1", "name": "Primary"}],
         compliance_status={"frameworks": [
             {"framework_id": "fedramp-moderate", "progress": 80, "status": "implemented"}
         ]}
     )
-    client.get_system = AsyncMock(
-        side_effect=PretorianClientError("System not found")
-    )
     mock_config = MagicMock()
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-unknown-id",
+        "active_system_name": "Retired System",
         "active_framework_id": "fedramp-moderate",
     }.get(key)
     with patch("pretorin.client.config.Config", return_value=mock_config):
         result = _run_with_mock_client(["--json", "context", "show"], client)
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    # system_name should fall back to system_id
-    assert payload["active_system_name"] == "sys-unknown-id"
+    assert payload["active_system_name"] == "Retired System"
+    assert payload["valid"] is False
+    assert payload["validation_state"] == "invalid"
+    assert "no longer exists" in payload["validation_error"]
 
 
 # ---------------------------------------------------------------------------
-# _context_show — lines 433-434 (compliance status PretorianClientError)
+# _context_show — compliance status PretorianClientError
 # ---------------------------------------------------------------------------
 
 
 def test_context_show_compliance_status_error_keeps_defaults():
-    """Lines 433-434: progress stays 0, status stays 'unknown' when compliance call fails."""
-    client = _make_client()
+    """Progress defaults remain and validation becomes unverified when compliance lookup fails."""
+    client = _make_client(systems=[{"id": "sys-1", "name": "Primary"}])
     client.get_system_compliance_status = AsyncMock(
         side_effect=PretorianClientError("compliance error")
     )
@@ -560,6 +564,29 @@ def test_context_show_compliance_status_error_keeps_defaults():
     payload = json.loads(result.stdout)
     assert payload["progress"] == 0
     assert payload["status"] == "unknown"
+    assert payload["valid"] is None
+    assert payload["validation_state"] == "unverified"
+    assert "Could not validate framework membership" in payload["validation_error"]
+
+
+def test_context_show_marks_missing_framework_as_invalid():
+    """Stored framework should be marked invalid when it no longer belongs to the system."""
+    client = _make_client(
+        systems=[{"id": "sys-1", "name": "Primary"}],
+        compliance_status={"frameworks": [{"framework_id": "fedramp-low", "progress": 10, "status": "in_progress"}]},
+    )
+    mock_config = MagicMock()
+    mock_config.get.side_effect = lambda key, *a: {
+        "active_system_id": "sys-1",
+        "active_framework_id": "fedramp-moderate",
+    }.get(key)
+    with patch("pretorin.client.config.Config", return_value=mock_config):
+        result = _run_with_mock_client(["--json", "context", "show"], client)
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["valid"] is False
+    assert payload["validation_state"] == "invalid"
+    assert "Available frameworks: fedramp-low" in payload["validation_error"]
 
 
 # ---------------------------------------------------------------------------
@@ -570,6 +597,7 @@ def test_context_show_compliance_status_error_keeps_defaults():
 def test_context_show_non_json_with_live_data():
     """Lines 447-448: renders a Panel in non-JSON mode with live system data."""
     client = _make_client(
+        systems=[{"id": "sys-1", "name": "Primary"}],
         compliance_status={"frameworks": [
             {"framework_id": "fedramp-moderate", "progress": 80, "status": "implemented"}
         ]}
@@ -586,9 +614,8 @@ def test_context_show_non_json_with_live_data():
 
 
 def test_context_show_non_json_system_error_and_compliance_error():
-    """Lines 423-424, 433-434, 447-448: both get_system and compliance fail, non-JSON path."""
-    client = _make_client()
-    client.get_system = AsyncMock(side_effect=PretorianClientError("not found"))
+    """Non-JSON path surfaces framework validation problems instead of silently falling back."""
+    client = _make_client(systems=[{"id": "sys-1", "name": "Primary"}])
     client.get_system_compliance_status = AsyncMock(
         side_effect=PretorianClientError("compliance error")
     )
@@ -601,3 +628,37 @@ def test_context_show_non_json_system_error_and_compliance_error():
         result = _run_with_mock_client(["context", "show"], client)
     assert result.exit_code == 0
     assert "Active Context" in result.output
+    assert "Could not validate framework membership" in result.output
+
+
+def test_context_show_quiet_outputs_single_line():
+    """Quiet mode should emit a compact one-line summary."""
+    client = _make_client(
+        systems=[{"id": "sys-1", "name": "Primary"}],
+        compliance_status={"frameworks": [{"framework_id": "fedramp-moderate", "progress": 80, "status": "implemented"}]},
+    )
+    mock_config = MagicMock()
+    mock_config.get.side_effect = lambda key, *a: {
+        "active_system_id": "sys-1",
+        "active_framework_id": "fedramp-moderate",
+    }.get(key)
+    with patch("pretorin.client.config.Config", return_value=mock_config):
+        result = _run_with_mock_client(["context", "show", "--quiet"], client)
+    assert result.exit_code == 0
+    assert "Primary (sys-1) / fedramp-moderate [implemented, 80%]" in result.output
+
+
+def test_context_show_check_exits_nonzero_for_stale_context():
+    """Check mode should fail fast when stored context points at a missing system."""
+    client = _make_client(systems=[{"id": "sys-1", "name": "Primary"}])
+    mock_config = MagicMock()
+    mock_config.get.side_effect = lambda key, *a: {
+        "active_system_id": "sys-missing",
+        "active_system_name": "Retired System",
+        "active_framework_id": "fedramp-moderate",
+    }.get(key)
+    with patch("pretorin.client.config.Config", return_value=mock_config):
+        result = _run_with_mock_client(["context", "show", "--quiet", "--check"], client)
+    assert result.exit_code == 1
+    assert "Retired System (sys-missing)" in result.output
+    assert "invalid" in result.output

--- a/tests/test_client_auth_coverage.py
+++ b/tests/test_client_auth_coverage.py
@@ -91,6 +91,7 @@ def test_store_credentials_without_url_resets_custom_endpoint_to_default(isolate
 def test_store_credentials_clears_active_context_when_api_key_changes(isolated_config: Path) -> None:
     cfg = config_module.Config()
     cfg.active_system_id = "system-local"
+    cfg.active_system_name = "Local System"
     cfg.active_framework_id = "fedramp-moderate"
     cfg.api_base_url = "http://localhost:8000/api/v1/public"
     cfg.model_api_base_url = "http://localhost:8000/v1"
@@ -100,12 +101,14 @@ def test_store_credentials_clears_active_context_when_api_key_changes(isolated_c
 
     reloaded = config_module.Config()
     assert reloaded.active_system_id is None
+    assert reloaded.active_system_name is None
     assert reloaded.active_framework_id is None
 
 
 def test_store_credentials_clears_active_context_when_api_url_changes(isolated_config: Path) -> None:
     cfg = config_module.Config()
     cfg.active_system_id = "system-local"
+    cfg.active_system_name = "Local System"
     cfg.active_framework_id = "fedramp-moderate"
     cfg.api_base_url = "http://localhost:8000/api/v1/public"
     cfg.model_api_base_url = "http://localhost:8000/v1"
@@ -115,6 +118,7 @@ def test_store_credentials_clears_active_context_when_api_url_changes(isolated_c
 
     reloaded = config_module.Config()
     assert reloaded.active_system_id is None
+    assert reloaded.active_system_name is None
     assert reloaded.active_framework_id is None
 
 
@@ -123,12 +127,14 @@ def test_store_credentials_preserves_active_context_when_credentials_unchanged(i
 
     cfg = config_module.Config()
     cfg.active_system_id = "system-prod"
+    cfg.active_system_name = "Production System"
     cfg.active_framework_id = "soc2"
 
     store_credentials("same-key", api_base_url="https://platform.pretorin.com/api/v1/public")
 
     reloaded = config_module.Config()
     assert reloaded.active_system_id == "system-prod"
+    assert reloaded.active_system_name == "Production System"
     assert reloaded.active_framework_id == "soc2"
 
 

--- a/tests/test_client_config_coverage.py
+++ b/tests/test_client_config_coverage.py
@@ -245,11 +245,24 @@ class TestActiveContextSetters:
         cfg.active_system_id = "sys-abc"
         assert cfg.active_system_id == "sys-abc"
 
-    def test_active_system_id_setter_with_none_deletes_key(self, isolated_config: Path):
+    def test_active_system_id_setter_with_none_deletes_cached_name_too(self, isolated_config: Path):
         cfg = Config()
         cfg.set("active_system_id", "sys-to-delete")
+        cfg.set("active_system_name", "System To Delete")
         cfg.active_system_id = None
         assert cfg.active_system_id is None
+        assert cfg.active_system_name is None
+
+    def test_active_system_name_setter_with_value(self, isolated_config: Path):
+        cfg = Config()
+        cfg.active_system_name = "Friendly System"
+        assert cfg.active_system_name == "Friendly System"
+
+    def test_active_system_name_setter_with_none_deletes_key(self, isolated_config: Path):
+        cfg = Config()
+        cfg.set("active_system_name", "Name To Delete")
+        cfg.active_system_name = None
+        assert cfg.active_system_name is None
 
     def test_active_framework_id_setter_with_value(self, isolated_config: Path):
         cfg = Config()

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "pretorin"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- validate stored CLI context against the platform and surface invalid or unverified scope clearly
- add `pretorin context show --quiet` and `--check`, plus cached system-name display for stale or offline context
- bump the release to `0.8.6` and refresh README, CLI docs, MCP docs, changelog, and the bundled Pretorin skill

## Testing
- `uv run --extra dev ruff check src/pretorin`
- `uv run --extra dev ruff format --check src/pretorin`
- `uv run --extra dev mypy src/pretorin`
- `uv run --extra dev pytest -q`

## Notes
- `docs/book/` was not regenerated in this environment because `mdbook`/`cargo` is not installed locally.
