### PR TITLE
fix(config): require re-auth when changing API endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.9.4"
+version = "0.9.5"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/cli/config.py
+++ b/src/pretorin/cli/config.py
@@ -1,9 +1,13 @@
 """Configuration CLI commands for Pretorin."""
 
+import asyncio
+
 import typer
 from rich import print as rprint
 from rich.table import Table
 
+from pretorin.client.api import AuthenticationError, PretorianClient, PretorianClientError
+from pretorin.client.auth import _derive_model_api_base_url, store_credentials
 from pretorin.client.config import (
     CONFIG_FILE,
     ENV_API_BASE_URL,
@@ -49,7 +53,45 @@ def config_set(
         raise typer.Exit(1)
 
     config = Config()
-    config.set(key, value)
+
+    # Platform URL changes require re-authentication
+    if key in {"api_base_url", "platform_api_base_url"}:
+        previous = config.platform_api_base_url
+        if value.rstrip("/") != previous.rstrip("/"):
+            rprint(f"[#FF9010]→[/#FF9010] Changing API endpoint to: {value}")
+            rprint("[dim]A new API key is required for this endpoint.[/dim]\n")
+            api_key = typer.prompt("Enter your API key for the new endpoint", hide_input=True, default="")
+            if not api_key:
+                rprint("[#FF9010]→[/#FF9010] API key is required. Aborting.")
+                raise typer.Exit(1)
+
+            async def _validate_and_store() -> None:
+                client = PretorianClient(api_key=api_key, api_base_url=value)
+                try:
+                    await client.validate_api_key()
+                    store_credentials(api_key, value)
+                    rprint(f"\n[#95D7E0]✓[/#95D7E0] Authenticated and switched to {value}")
+                    model_url = _derive_model_api_base_url(value)
+                    rprint(f"[#95D7E0]✓[/#95D7E0] Model API URL set to {model_url}")
+                except AuthenticationError as e:
+                    rprint(f"\n[#FF9010]→[/#FF9010] Authentication failed: {e.message}")
+                    rprint("[dim]Endpoint not changed.[/dim]")
+                    raise typer.Exit(1)
+                except PretorianClientError as e:
+                    rprint(f"\n[#FF9010]→[/#FF9010] {e.message}")
+                    rprint("[dim]Endpoint not changed.[/dim]")
+                    raise typer.Exit(1)
+                finally:
+                    await client.close()
+
+            asyncio.run(_validate_and_store())
+            return
+
+    # Use property setters for known URL keys to keep config consistent
+    if key == "model_api_base_url":
+        config.model_api_base_url = value
+    else:
+        config.set(key, value)
     rprint(f"[#95D7E0]✓[/#95D7E0] Set {key} = {value}")
 
 

--- a/tests/test_cli_config_coverage.py
+++ b/tests/test_cli_config_coverage.py
@@ -5,7 +5,7 @@ Covers: config get, config set, config list, config path commands.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -109,9 +109,34 @@ class TestConfigSet:
         assert "custom_key" in result.output
         assert "my-value" in result.output
 
-    def test_set_api_base_url_succeeds(self) -> None:
-        """api_base_url can be set (only api_key is blocked)."""
+    def test_set_api_base_url_prompts_for_api_key(self) -> None:
+        """Changing api_base_url prompts for a new API key and validates it."""
         mock_config = MagicMock()
+        mock_config.platform_api_base_url = "https://platform.pretorin.com/api/v1/public"
+
+        mock_client = AsyncMock()
+        mock_client.validate_api_key = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with (
+            patch("pretorin.cli.config.Config", return_value=mock_config),
+            patch("pretorin.cli.config.PretorianClient", return_value=mock_client),
+            patch("pretorin.cli.config.store_credentials") as mock_store,
+        ):
+            result = runner.invoke(
+                app,
+                ["config", "set", "api_base_url", "https://self-hosted.example.com"],
+                input="test-api-key\n",
+            )
+
+        assert result.exit_code == 0
+        assert "Authenticated" in result.output or "switched" in result.output
+        mock_store.assert_called_once_with("test-api-key", "https://self-hosted.example.com")
+
+    def test_set_api_base_url_no_change_skips_reauth(self) -> None:
+        """Setting api_base_url to the same value skips re-authentication."""
+        mock_config = MagicMock()
+        mock_config.platform_api_base_url = "https://self-hosted.example.com"
         mock_config.set = MagicMock()
 
         with patch("pretorin.cli.config.Config", return_value=mock_config):
@@ -121,7 +146,6 @@ class TestConfigSet:
             )
 
         assert result.exit_code == 0
-        mock_config.set.assert_called_once_with("api_base_url", "https://self-hosted.example.com")
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "pretorin"
-version = "0.8.7"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- **Bug fix**: `config set api_base_url` was bypassing property setters, so `platform_api_base_url` (which the client reads first) stayed pointed at production — silently ignoring the change.
- **Re-auth on URL change**: Changing the platform URL now prompts for a new API key, validates it against the new endpoint, and clears the active system/framework context via `store_credentials()`.
- Bumps version to 0.9.5.

## Test plan
- [x] Existing tests updated and passing (1124 passed)
- [ ] Manual: `pretorin config set api_base_url http://localhost:8080/api/v1/public` prompts for API key, validates, updates all three URL keys
- [ ] Manual: `pretorin config set api_base_url <same-url>` is a no-op (no prompt)
- [ ] Manual: `pretorin config list` shows consistent URLs after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)