### PR TITLE
feat: fetch org CLI model from platform AI settings

### DIFF
--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -972,3 +972,13 @@ class PretorianClient:
             json=payload,
         )
         return data
+
+    # ---- AI Settings ----
+
+    async def get_org_ai_settings(self) -> dict[str, Any]:
+        """Fetch the organization's AI model settings.
+
+        Returns:
+            Dict with ``cli_model`` and ``default_model`` keys.
+        """
+        return await self._request("GET", "/ai-settings")

--- a/src/pretorin/client/config.py
+++ b/src/pretorin/client/config.py
@@ -36,6 +36,9 @@ def _as_bool(value: Any) -> bool:
 class Config:
     """Manages Pretorin CLI configuration."""
 
+    # Class-level cache so all Config instances share the fetched org model.
+    _org_cli_model: str | None = None
+
     def __init__(self) -> None:
         self._config: dict[str, Any] = {}
         self._load()
@@ -225,9 +228,28 @@ class Config:
 
     @property
     def openai_model(self) -> str:
-        """Get the OpenAI model (env var takes precedence)."""
+        """Get the OpenAI model.
+
+        Precedence:
+        1. ``OPENAI_MODEL`` env var
+        2. Local ``openai_model`` config key
+        3. Org AI settings fetched from the platform (cached)
+        4. ``"gpt-4o"`` default
+        """
         env = os.environ.get(ENV_OPENAI_MODEL)
-        return env if env else self.get("openai_model", "gpt-4o")
+        if env:
+            return env
+        local = self.get("openai_model")
+        if local:
+            return local
+        if self._org_cli_model is not None:
+            return self._org_cli_model
+        return "gpt-4o"
+
+    @classmethod
+    def set_org_cli_model(cls, model: str) -> None:
+        """Cache the org's CLI model fetched from the platform API."""
+        cls._org_cli_model = model
 
     @property
     def codex_home(self) -> Path:

--- a/src/pretorin/workflows/ai_generation.py
+++ b/src/pretorin/workflows/ai_generation.py
@@ -3,13 +3,37 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from pretorin.cli.context import resolve_execution_context
 from pretorin.client import PretorianClient
 from pretorin.client.api import PretorianClientError
+from pretorin.client.config import Config
 from pretorin.utils import normalize_control_id
+
+logger = logging.getLogger(__name__)
+
+
+async def _ensure_org_model_cached(client: PretorianClient) -> None:
+    """Fetch the org's CLI model from the platform and cache it on Config.
+
+    This is a best-effort call — if it fails (e.g. no API token, network
+    error, old server without the endpoint), we silently fall back to the
+    local config / default.
+    """
+    config = Config()
+    if config._org_cli_model is not None:
+        return  # already cached this session
+    try:
+        data = await client.get_org_ai_settings()
+        cli_model = data.get("cli_model")
+        if cli_model:
+            config.set_org_cli_model(cli_model)
+            logger.debug("Using org CLI model from platform: %s", cli_model)
+    except Exception:
+        logger.debug("Could not fetch org AI settings, using local config")
 
 
 def _strip_json_fence(text: str) -> str:
@@ -100,6 +124,10 @@ async def draft_control_artifacts(
 ) -> dict[str, Any]:
     """Generate read-only narrative and evidence-gap drafts for a control."""
     from pretorin.agent.codex_agent import CodexAgent
+
+    # Pre-fetch org model setting so CodexAgent picks it up via Config
+    if model is None:
+        await _ensure_org_model_cached(client)
 
     normalized_control_id = normalize_control_id(control_id)
     system_id, resolved_framework_id = await resolve_execution_context(

--- a/tests/test_client_config_coverage.py
+++ b/tests/test_client_config_coverage.py
@@ -322,6 +322,8 @@ class TestOpenAIProperties:
         assert cfg2.openai_model == "gpt-3.5-turbo"
 
     def test_openai_model_default_is_gpt4o(self, isolated_config: Path):
+        # Reset class-level cache that may leak from other tests
+        Config._org_cli_model = None
         cfg = Config()
         assert cfg.openai_model == "gpt-4o"
 


### PR DESCRIPTION
## Summary
- CLI now fetches the org's configured CLI model from the platform API (`GET /api/v1/public/ai-settings`) before running AI workflows
- The fetched model is cached for the session and used as the default when no explicit `--model` flag or `OPENAI_MODEL` env var is set
- Best-effort: silently falls back to local config if the API call fails

## Precedence
1. `OPENAI_MODEL` env var (highest)
2. Local `openai_model` in `~/.pretorin/config.json`
3. Org setting from platform API (new)
4. `gpt-4o` default

## Dependencies
- Requires [monorepo PR #334](https://github.com/pretorin-ai/monorepo/pull/334) for the `GET /api/v1/public/ai-settings` endpoint

## Test plan
- [ ] Run `pretorin agent run` with org model set to `gpt-4o-mini` via web UI → CLI uses `gpt-4o-mini`
- [ ] Set `OPENAI_MODEL=o3-mini` → CLI uses `o3-mini` (env var overrides)
- [ ] Disconnect from platform → CLI falls back to `gpt-4o` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)