### PR TITLE
feat: STIG/CCI commands, scanner module, scan orchestration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.11.0"
+version = "0.12.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/src/pretorin/agent/skills.py
+++ b/src/pretorin/agent/skills.py
@@ -184,6 +184,55 @@ SKILLS: dict[str, Skill] = {
         ],
         max_turns=25,
     ),
+    "stig-scan": Skill(
+        name="stig-scan",
+        description="Run STIG compliance scans against a system",
+        system_prompt=(
+            "You are a STIG compliance scanning expert. Your task is to:\n"
+            "1. Check the system's STIG applicability (which STIGs apply)\n"
+            "2. Get the test manifest (rules to evaluate)\n"
+            "3. Report what scanners are available and what rules they cover\n"
+            "4. Summarize the scan plan and any gaps in automated coverage\n\n"
+            "Start by listing the system, then check STIG applicability. "
+            "If applicable STIGs exist, get the test manifest and summarize "
+            "the rules by severity and scanner availability."
+        ),
+        tool_names=[
+            "list_systems",
+            "get_system",
+            "get_compliance_status",
+            "list_stigs",
+            "get_stig_applicability",
+            "get_test_manifest",
+            "get_cci_status",
+        ],
+        max_turns=15,
+    ),
+    "cci-assessment": Skill(
+        name="cci-assessment",
+        description="Assess CCI compliance for a specific control",
+        system_prompt=(
+            "You are a CCI compliance assessment expert. Your task is to:\n"
+            "1. Get the control context and implementation status\n"
+            "2. List CCIs for this control\n"
+            "3. Check CCI-level test results (pass/fail/not tested)\n"
+            "4. Identify gaps: which CCIs have no test coverage\n"
+            "5. Recommend actions for untested CCIs\n\n"
+            "Present results as a traceability chain showing the full path "
+            "from control → CCIs → STIG rules → test results."
+        ),
+        tool_names=[
+            "get_system",
+            "get_control",
+            "get_control_context",
+            "get_control_implementation",
+            "list_ccis",
+            "get_cci",
+            "get_cci_status",
+            "search_evidence",
+        ],
+        max_turns=15,
+    ),
 }
 
 

--- a/src/pretorin/cli/cci.py
+++ b/src/pretorin/cli/cci.py
@@ -136,7 +136,12 @@ async def _show_cci(cci_id: str) -> None:
             table.add_row(
                 r.get("stig_id", ""),
                 r.get("rule_id", "")[:30],
-                f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]" if sev else "",
+                (
+                    f"[{severity_styles.get(sev, '')}]"
+                    f"{sev.upper().replace('_', ' ')}"
+                    f"[/{severity_styles.get(sev, '')}]"
+                    if sev else ""
+                ),
                 (r.get("title", "") or "")[:50],
             )
 
@@ -199,9 +204,16 @@ async def _chain(control_id: str, system: str | None) -> None:
 
         if status_info:
             s = status_info["status"]
-            icon = {"pass": "✓", "fail": "✗", "mixed": "◐", "not_tested": "—"}.get(s, "?")
-            color = {"pass": "green", "fail": "red", "mixed": "yellow", "not_tested": "dim"}.get(s, "")
-            label = f"[{color}]{icon} {cci_id}[/{color}]  {s.upper()}  ({status_info['passing_rules']}/{status_info['total_rules']} rules)"
+            icon_map = {"pass": "✓", "fail": "✗", "mixed": "◐", "not_tested": "—"}
+            color_map = {"pass": "green", "fail": "red", "mixed": "yellow", "not_tested": "dim"}
+            icon = icon_map.get(s, "?")
+            color = color_map.get(s, "")
+            passing = status_info["passing_rules"]
+            total = status_info["total_rules"]
+            label = (
+                f"[{color}]{icon} {cci_id}[/{color}]  "
+                f"{s.upper()}  ({passing}/{total} rules)"
+            )
         else:
             label = f"[dim]— {cci_id}[/dim]  [{cci.get('cci_type', '')}]"
 

--- a/src/pretorin/cli/cci.py
+++ b/src/pretorin/cli/cci.py
@@ -53,9 +53,7 @@ async def _list_ccis(control: str | None, status: str | None, limit: int) -> Non
     async with PretorianClient() as client:
         require_auth(client)
         try:
-            data = await client.list_ccis(
-                nist_control_id=control, status=status, limit=limit
-            )
+            data = await client.list_ccis(nist_control_id=control, status=status, limit=limit)
         except PretorianClientError as e:
             rprint(f"[red]Error: {e.message}[/red]")
             raise typer.Exit(1)
@@ -137,10 +135,9 @@ async def _show_cci(cci_id: str) -> None:
                 r.get("stig_id", ""),
                 r.get("rule_id", "")[:30],
                 (
-                    f"[{severity_styles.get(sev, '')}]"
-                    f"{sev.upper().replace('_', ' ')}"
-                    f"[/{severity_styles.get(sev, '')}]"
-                    if sev else ""
+                    f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]"
+                    if sev
+                    else ""
                 ),
                 (r.get("title", "") or "")[:50],
             )
@@ -165,9 +162,7 @@ async def _chain(control_id: str, system: str | None) -> None:
 
         # Get CCIs for this control
         try:
-            cci_data = await client.list_ccis(
-                nist_control_id=control_id.lower(), limit=500
-            )
+            cci_data = await client.list_ccis(nist_control_id=control_id.lower(), limit=500)
         except PretorianClientError as e:
             rprint(f"[red]Error: {e.message}[/red]")
             raise typer.Exit(1)
@@ -179,9 +174,7 @@ async def _chain(control_id: str, system: str | None) -> None:
         if system:
             try:
                 system_id, _ = await resolve_execution_context(client, system=system)
-                status_data = await client.get_cci_status(
-                    system_id, nist_control_id=control_id.lower()
-                )
+                status_data = await client.get_cci_status(system_id, nist_control_id=control_id.lower())
                 for item in status_data.get("ccis", []):
                     cci_status[item["cci_id"]] = item
             except PretorianClientError:
@@ -210,10 +203,7 @@ async def _chain(control_id: str, system: str | None) -> None:
             color = color_map.get(s, "")
             passing = status_info["passing_rules"]
             total = status_info["total_rules"]
-            label = (
-                f"[{color}]{icon} {cci_id}[/{color}]  "
-                f"{s.upper()}  ({passing}/{total} rules)"
-            )
+            label = f"[{color}]{icon} {cci_id}[/{color}]  {s.upper()}  ({passing}/{total} rules)"
         else:
             label = f"[dim]— {cci_id}[/dim]  [{cci.get('cci_type', '')}]"
 
@@ -225,8 +215,6 @@ async def _chain(control_id: str, system: str | None) -> None:
             for sr in status_info.get("stig_results", [])[:5]:
                 sr_icon = "✓" if sr["status"] == "pass" else "✗"
                 sr_color = "green" if sr["status"] == "pass" else "red"
-                cci_branch.add(
-                    f"  [{sr_color}]{sr_icon}[/{sr_color}] {sr.get('stig_id', '')} {sr.get('rule_id', '')}"
-                )
+                cci_branch.add(f"  [{sr_color}]{sr_icon}[/{sr_color}] {sr.get('stig_id', '')} {sr.get('rule_id', '')}")
 
     rprint(tree)

--- a/src/pretorin/cli/cci.py
+++ b/src/pretorin/cli/cci.py
@@ -1,0 +1,220 @@
+"""CCI (Control Correlation Identifier) browsing commands for Pretorin."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+from rich import print as rprint
+from rich.panel import Panel
+from rich.table import Table
+from rich.tree import Tree
+
+from pretorin.cli.output import is_json_mode, print_json
+
+app = typer.Typer(
+    name="cci",
+    help="Browse CCIs and the full traceability chain.",
+    no_args_is_help=True,
+)
+
+
+@app.command("list")
+def cci_list(
+    control: str | None = typer.Option(None, "--control", "-c", help="Filter by NIST 800-53 control ID (e.g., ac-2)"),
+    status: str | None = typer.Option(None, "--status", help="Filter by status (draft/published/deprecated)"),
+    limit: int = typer.Option(100, "--limit", "-l", help="Max results"),
+) -> None:
+    """List CCIs, optionally filtered by NIST 800-53 control."""
+    asyncio.run(_list_ccis(control, status, limit))
+
+
+@app.command("show")
+def cci_show(
+    cci_id: str = typer.Argument(..., help="CCI ID (e.g., CCI-000015)"),
+) -> None:
+    """Show CCI detail with linked SRGs and STIG rules."""
+    asyncio.run(_show_cci(cci_id))
+
+
+@app.command("chain")
+def cci_chain(
+    control_id: str = typer.Argument(..., help="NIST 800-53 control ID (e.g., ac-2)"),
+    system: str | None = typer.Option(None, "--system", "-s", help="System for test results"),
+) -> None:
+    """Show full traceability chain: Control → CCIs → STIG rules (→ test results)."""
+    asyncio.run(_chain(control_id, system))
+
+
+async def _list_ccis(control: str | None, status: str | None, limit: int) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            data = await client.list_ccis(
+                nist_control_id=control, status=status, limit=limit
+            )
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    items = data.get("items", [])
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    if not items:
+        rprint("[dim]No CCI entries found.[/dim]")
+        return
+
+    table = Table(title=f"CCIs ({data.get('total', len(items))} total)")
+    table.add_column("CCI ID", style="bold")
+    table.add_column("Control", style="cyan")
+    table.add_column("Type")
+    table.add_column("Definition")
+
+    for item in items:
+        table.add_row(
+            item["cci_id"],
+            item["nist_control_id"].upper(),
+            item.get("cci_type", ""),
+            (item.get("definition", "") or "")[:60],
+        )
+
+    rprint(table)
+
+
+async def _show_cci(cci_id: str) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    # Normalize CCI ID format
+    if not cci_id.startswith("CCI-"):
+        cci_id = f"CCI-{cci_id.zfill(6)}"
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            data = await client.get_cci(cci_id)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    # Build detail panel
+    content = (
+        f"[bold]{data['cci_id']}[/bold] → {data['nist_control_id'].upper()}\n\n"
+        f"[dim]Type:[/dim]   {data.get('cci_type', 'N/A')}\n"
+        f"[dim]Status:[/dim] {data['status']}\n\n"
+        f"[bold]Definition:[/bold]\n{data['definition']}\n"
+    )
+
+    if data.get("assessment_objective"):
+        content += f"\n[bold]Assessment Objective:[/bold]\n{data['assessment_objective']}\n"
+
+    rprint(Panel(content, title="CCI Detail", border_style="#FF9010"))
+
+    # Show linked STIG rules
+    stig_rules = data.get("stig_rules", [])
+    if stig_rules:
+        table = Table(title=f"STIG Rules ({len(stig_rules)})")
+        table.add_column("STIG", style="cyan")
+        table.add_column("Rule ID", style="bold")
+        table.add_column("Severity")
+        table.add_column("Title")
+
+        severity_styles = {"cat_i": "red bold", "cat_ii": "yellow", "cat_iii": "green"}
+
+        for r in stig_rules:
+            sev = r.get("severity", "")
+            table.add_row(
+                r.get("stig_id", ""),
+                r.get("rule_id", "")[:30],
+                f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]" if sev else "",
+                (r.get("title", "") or "")[:50],
+            )
+
+        rprint(table)
+
+    # Show linked SRGs
+    srgs = data.get("srgs", [])
+    if srgs:
+        rprint(f"\n[bold]SRG Requirements ({len(srgs)}):[/bold]")
+        for s in srgs:
+            rprint(f"  {s['srg_id']}  {s.get('title', '')[:60]}")
+
+
+async def _chain(control_id: str, system: str | None) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+
+        # Get CCIs for this control
+        try:
+            cci_data = await client.list_ccis(
+                nist_control_id=control_id.lower(), limit=500
+            )
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+        ccis = cci_data.get("items", [])
+
+        # Get test results if system specified
+        cci_status = {}
+        if system:
+            try:
+                system_id, _ = await resolve_execution_context(client, system=system)
+                status_data = await client.get_cci_status(
+                    system_id, nist_control_id=control_id.lower()
+                )
+                for item in status_data.get("ccis", []):
+                    cci_status[item["cci_id"]] = item
+            except PretorianClientError:
+                pass  # No test results available
+
+    if is_json_mode():
+        print_json({"control_id": control_id, "ccis": ccis, "cci_status": cci_status})
+        return
+
+    if not ccis:
+        rprint(f"[dim]No CCIs found for {control_id.upper()}[/dim]")
+        return
+
+    # Build tree view
+    tree = Tree(f"[bold]{control_id.upper()}[/bold]  ({len(ccis)} CCIs)")
+
+    for cci in ccis:
+        cci_id = cci["cci_id"]
+        status_info = cci_status.get(cci_id)
+
+        if status_info:
+            s = status_info["status"]
+            icon = {"pass": "✓", "fail": "✗", "mixed": "◐", "not_tested": "—"}.get(s, "?")
+            color = {"pass": "green", "fail": "red", "mixed": "yellow", "not_tested": "dim"}.get(s, "")
+            label = f"[{color}]{icon} {cci_id}[/{color}]  {s.upper()}  ({status_info['passing_rules']}/{status_info['total_rules']} rules)"
+        else:
+            label = f"[dim]— {cci_id}[/dim]  [{cci.get('cci_type', '')}]"
+
+        cci_branch = tree.add(label)
+        cci_branch.add(f"[dim]{(cci.get('definition', '') or '')[:80]}[/dim]")
+
+        # Show STIG results if available
+        if status_info:
+            for sr in status_info.get("stig_results", [])[:5]:
+                sr_icon = "✓" if sr["status"] == "pass" else "✗"
+                sr_color = "green" if sr["status"] == "pass" else "red"
+                cci_branch.add(
+                    f"  [{sr_color}]{sr_icon}[/{sr_color}] {sr.get('stig_id', '')} {sr.get('rule_id', '')}"
+                )
+
+    rprint(tree)

--- a/src/pretorin/cli/main.py
+++ b/src/pretorin/cli/main.py
@@ -13,6 +13,7 @@ from pretorin import __version__
 from pretorin.cli.agent import app as agent_app
 from pretorin.cli.auth import app as auth_app
 from pretorin.cli.campaign import app as campaign_app
+from pretorin.cli.cci import app as cci_app
 from pretorin.cli.commands import app as frameworks_app
 from pretorin.cli.config import app as config_app
 from pretorin.cli.context import app as context_app
@@ -25,8 +26,10 @@ from pretorin.cli.notes import app as notes_app
 from pretorin.cli.output import set_json_mode
 from pretorin.cli.policy import app as policy_app
 from pretorin.cli.review import app as review_app
+from pretorin.cli.scan import app as scan_app
 from pretorin.cli.scope import app as scope_app
 from pretorin.cli.skill import app as skill_app
+from pretorin.cli.stig import app as stig_app
 from pretorin.cli.vendor import app as vendor_app
 
 console = Console()
@@ -169,6 +172,9 @@ app.add_typer(scope_app, name="scope", help="Stateful scope questionnaire workfl
 app.add_typer(agent_app, name="agent", help="Autonomous compliance agent")
 app.add_typer(skill_app, name="skill", help="Install/manage the Pretorin skill for AI agents")
 app.add_typer(vendor_app, name="vendor", help="Vendor management and evidence linking")
+app.add_typer(stig_app, name="stig", help="Browse STIG benchmarks, rules, and applicability")
+app.add_typer(cci_app, name="cci", help="Browse CCIs and the full traceability chain")
+app.add_typer(scan_app, name="scan", help="Run STIG compliance scans and view results")
 app.add_typer(harness_app, name="harness", help="[Deprecated] AI harness wrapper")
 
 # Add auth commands directly to root

--- a/src/pretorin/cli/scan.py
+++ b/src/pretorin/cli/scan.py
@@ -1,0 +1,298 @@
+"""Scan commands — run STIG compliance scans and manage results."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+from rich import print as rprint
+from rich.panel import Panel
+from rich.table import Table
+
+from pretorin.cli.output import is_json_mode, print_json
+
+app = typer.Typer(
+    name="scan",
+    help="Run STIG compliance scans and view results.",
+    no_args_is_help=True,
+)
+
+
+@app.command("doctor")
+def scan_doctor() -> None:
+    """Check which scanner tools are installed and available."""
+    asyncio.run(_doctor())
+
+
+@app.command("manifest")
+def scan_manifest(
+    system: str | None = typer.Option(None, "--system", "-s", help="System name or ID"),
+    stig_id: str | None = typer.Option(None, "--stig", help="Filter to specific STIG"),
+) -> None:
+    """Show test manifest for the active system."""
+    asyncio.run(_manifest(system, stig_id))
+
+
+@app.command("run")
+def scan_run(
+    system: str | None = typer.Option(None, "--system", "-s", help="System name or ID"),
+    stig_id: str | None = typer.Option(None, "--stig", help="Specific STIG to scan"),
+    tool: str | None = typer.Option(None, "--tool", "-t", help="Force specific scanner (openscap, inspec, manual)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview scan plan without executing"),
+) -> None:
+    """Run STIG compliance scans against a system."""
+    asyncio.run(_run_scan(system, stig_id, tool, dry_run))
+
+
+@app.command("results")
+def scan_results(
+    system: str | None = typer.Option(None, "--system", "-s", help="System name or ID"),
+    control: str | None = typer.Option(None, "--control", "-c", help="Filter by NIST control ID"),
+) -> None:
+    """Show latest CCI-level test results for the active system."""
+    asyncio.run(_results(system, control))
+
+
+async def _doctor() -> None:
+    from pretorin.scanners.orchestrator import ScanOrchestrator
+
+    orchestrator = ScanOrchestrator()
+    infos = await orchestrator.detect_scanners()
+
+    if is_json_mode():
+        print_json([
+            {
+                "name": info.name,
+                "version": info.version,
+                "available": info.available,
+                "supported_stigs": info.supported_stigs,
+                "install_hint": info.install_hint,
+            }
+            for info in infos
+        ])
+        return
+
+    table = Table(title="Scanner Availability")
+    table.add_column("Scanner", style="bold")
+    table.add_column("Status")
+    table.add_column("Version")
+    table.add_column("STIGs")
+    table.add_column("Install Hint", style="dim")
+
+    for info in infos:
+        status = "[green]✓ Available[/green]" if info.available else "[red]✗ Missing[/red]"
+        stigs = ", ".join(info.supported_stigs[:3])
+        if len(info.supported_stigs) > 3:
+            stigs += f" (+{len(info.supported_stigs) - 3})"
+        table.add_row(
+            info.name,
+            status,
+            info.version or "",
+            stigs,
+            info.install_hint if not info.available else "",
+        )
+
+    rprint(table)
+
+    available_count = sum(1 for i in infos if i.available)
+    rprint(f"\n[dim]{available_count}/{len(infos)} scanners available[/dim]")
+
+
+async def _manifest(system: str | None, stig_id: str | None) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            system_id, _ = await resolve_execution_context(client, system=system)
+            manifest = await client.get_test_manifest(system_id, stig_id=stig_id)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    if is_json_mode():
+        print_json(manifest)
+        return
+
+    stigs = manifest.get("applicable_stigs", [])
+    if not stigs:
+        rprint("[dim]No applicable STIGs found for this system.[/dim]")
+        rprint("[dim]Run 'pretorin stig applicable' to check STIG applicability.[/dim]")
+        return
+
+    total_rules = sum(len(s.get("rules", [])) for s in stigs)
+    rprint(Panel(
+        f"System: {manifest['system_id']}\n"
+        f"STIGs:  {len(stigs)}\n"
+        f"Rules:  {total_rules}",
+        title="Test Manifest",
+        border_style="#FF9010",
+    ))
+
+    for stig in stigs:
+        rules = stig.get("rules", [])
+        cat_i = sum(1 for r in rules if r.get("severity") == "cat_i")
+        cat_ii = sum(1 for r in rules if r.get("severity") == "cat_ii")
+        cat_iii = sum(1 for r in rules if r.get("severity") == "cat_iii")
+        rprint(
+            f"  [bold]{stig['stig_id']}[/bold] ({stig.get('stig_name', '')[:40]}) "
+            f"— {len(rules)} rules "
+            f"([red]CAT I: {cat_i}[/red] [yellow]CAT II: {cat_ii}[/yellow] [green]CAT III: {cat_iii}[/green])"
+        )
+
+
+async def _run_scan(
+    system: str | None, stig_id: str | None, tool: str | None, dry_run: bool
+) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+    from pretorin.scanners.orchestrator import ScanOrchestrator
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            system_id, _ = await resolve_execution_context(client, system=system)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+        orchestrator = ScanOrchestrator()
+
+        if dry_run:
+            rprint("[bold]Scan Plan (dry run)[/bold]\n")
+
+            # Detect scanners
+            infos = await orchestrator.detect_scanners()
+            available = [i for i in infos if i.available]
+            rprint(f"Available scanners: {', '.join(i.name for i in available)}")
+
+            # Get manifest
+            try:
+                manifest = await client.get_test_manifest(system_id, stig_id=stig_id)
+            except PretorianClientError as e:
+                rprint(f"[red]Error getting manifest: {e.message}[/red]")
+                raise typer.Exit(1)
+
+            plan = orchestrator.plan_scan(manifest, preferred_scanner=tool)
+
+            for step in plan.steps:
+                rprint(
+                    f"  [bold]{step.scanner_name}[/bold] → {step.benchmark_id} "
+                    f"({len(step.rules)} rules)"
+                )
+
+            if plan.unassigned_rules:
+                rprint(
+                    f"\n  [yellow]⚠ {len(plan.unassigned_rules)} rules have no "
+                    f"automated scanner (require manual review)[/yellow]"
+                )
+
+            rprint("\n[dim]Run without --dry-run to execute.[/dim]")
+            return
+
+        # Full scan
+        rprint("[bold]Starting STIG compliance scan...[/bold]\n")
+
+        try:
+            report = await orchestrator.run(
+                client,
+                system_id=system_id,
+                stig_id=stig_id,
+                preferred_scanner=tool,
+            )
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    if is_json_mode():
+        print_json({
+            "cli_run_id": report.cli_run_id,
+            "total": report.total,
+            "passed": report.passed,
+            "failed": report.failed,
+            "not_reviewed": report.not_reviewed,
+            "errors": report.errors,
+        })
+        return
+
+    # Display results summary
+    rprint(Panel(
+        f"Run ID:       {report.cli_run_id}\n"
+        f"Total rules:  {report.total}\n"
+        f"[green]Passed:       {report.passed}[/green]\n"
+        f"[red]Failed:       {report.failed}[/red]\n"
+        f"Not reviewed: {report.not_reviewed}",
+        title="Scan Complete",
+        border_style="#FF9010",
+    ))
+
+    if report.errors:
+        rprint(f"\n[yellow]Errors ({len(report.errors)}):[/yellow]")
+        for err in report.errors[:5]:
+            rprint(f"  [red]• {err}[/red]")
+
+
+async def _results(system: str | None, control: str | None) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            system_id, _ = await resolve_execution_context(client, system=system)
+            data = await client.get_cci_status(system_id, nist_control_id=control)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    ccis = data.get("ccis", [])
+    if not ccis:
+        rprint("[dim]No CCI test results found.[/dim]")
+        return
+
+    table = Table(title="CCI Compliance Status")
+    table.add_column("CCI", style="bold")
+    table.add_column("Control", style="cyan")
+    table.add_column("Status")
+    table.add_column("Rules", justify="right")
+    table.add_column("Pass", justify="right", style="green")
+    table.add_column("Fail", justify="right", style="red")
+    table.add_column("Last Tested", style="dim")
+
+    status_styles = {
+        "pass": "[green]✓ Pass[/green]",
+        "fail": "[red]✗ Fail[/red]",
+        "mixed": "[yellow]◐ Mixed[/yellow]",
+        "not_tested": "[dim]— Not tested[/dim]",
+    }
+
+    for cci in ccis:
+        table.add_row(
+            cci["cci_id"],
+            cci["nist_control_id"].upper(),
+            status_styles.get(cci["status"], cci["status"]),
+            str(cci["total_rules"]),
+            str(cci["passing_rules"]),
+            str(cci["failing_rules"]),
+            cci.get("last_tested", "")[:10] if cci.get("last_tested") else "",
+        )
+
+    rprint(table)
+
+    # Summary
+    total = len(ccis)
+    passing = sum(1 for c in ccis if c["status"] == "pass")
+    failing = sum(1 for c in ccis if c["status"] == "fail")
+    not_tested = sum(1 for c in ccis if c["status"] == "not_tested")
+    rprint(
+        f"\n[dim]Summary: {passing} passing, {failing} failing, "
+        f"{not_tested} not tested ({total} total CCIs)[/dim]"
+    )

--- a/src/pretorin/cli/scan.py
+++ b/src/pretorin/cli/scan.py
@@ -60,16 +60,18 @@ async def _doctor() -> None:
     infos = await orchestrator.detect_scanners()
 
     if is_json_mode():
-        print_json([
-            {
-                "name": info.name,
-                "version": info.version,
-                "available": info.available,
-                "supported_stigs": info.supported_stigs,
-                "install_hint": info.install_hint,
-            }
-            for info in infos
-        ])
+        print_json(
+            [
+                {
+                    "name": info.name,
+                    "version": info.version,
+                    "available": info.available,
+                    "supported_stigs": info.supported_stigs,
+                    "install_hint": info.install_hint,
+                }
+                for info in infos
+            ]
+        )
         return
 
     table = Table(title="Scanner Availability")
@@ -123,13 +125,13 @@ async def _manifest(system: str | None, stig_id: str | None) -> None:
         return
 
     total_rules = sum(len(s.get("rules", [])) for s in stigs)
-    rprint(Panel(
-        f"System: {manifest['system_id']}\n"
-        f"STIGs:  {len(stigs)}\n"
-        f"Rules:  {total_rules}",
-        title="Test Manifest",
-        border_style="#FF9010",
-    ))
+    rprint(
+        Panel(
+            f"System: {manifest['system_id']}\nSTIGs:  {len(stigs)}\nRules:  {total_rules}",
+            title="Test Manifest",
+            border_style="#FF9010",
+        )
+    )
 
     for stig in stigs:
         rules = stig.get("rules", [])
@@ -143,9 +145,7 @@ async def _manifest(system: str | None, stig_id: str | None) -> None:
         )
 
 
-async def _run_scan(
-    system: str | None, stig_id: str | None, tool: str | None, dry_run: bool
-) -> None:
+async def _run_scan(system: str | None, stig_id: str | None, tool: str | None, dry_run: bool) -> None:
     from pretorin.cli.commands import require_auth
     from pretorin.cli.context import resolve_execution_context
     from pretorin.client.api import PretorianClient, PretorianClientError
@@ -179,10 +179,7 @@ async def _run_scan(
             plan = orchestrator.plan_scan(manifest, preferred_scanner=tool)
 
             for step in plan.steps:
-                rprint(
-                    f"  [bold]{step.scanner_name}[/bold] → {step.benchmark_id} "
-                    f"({len(step.rules)} rules)"
-                )
+                rprint(f"  [bold]{step.scanner_name}[/bold] → {step.benchmark_id} ({len(step.rules)} rules)")
 
             if plan.unassigned_rules:
                 rprint(
@@ -208,26 +205,30 @@ async def _run_scan(
             raise typer.Exit(1)
 
     if is_json_mode():
-        print_json({
-            "cli_run_id": report.cli_run_id,
-            "total": report.total,
-            "passed": report.passed,
-            "failed": report.failed,
-            "not_reviewed": report.not_reviewed,
-            "errors": report.errors,
-        })
+        print_json(
+            {
+                "cli_run_id": report.cli_run_id,
+                "total": report.total,
+                "passed": report.passed,
+                "failed": report.failed,
+                "not_reviewed": report.not_reviewed,
+                "errors": report.errors,
+            }
+        )
         return
 
     # Display results summary
-    rprint(Panel(
-        f"Run ID:       {report.cli_run_id}\n"
-        f"Total rules:  {report.total}\n"
-        f"[green]Passed:       {report.passed}[/green]\n"
-        f"[red]Failed:       {report.failed}[/red]\n"
-        f"Not reviewed: {report.not_reviewed}",
-        title="Scan Complete",
-        border_style="#FF9010",
-    ))
+    rprint(
+        Panel(
+            f"Run ID:       {report.cli_run_id}\n"
+            f"Total rules:  {report.total}\n"
+            f"[green]Passed:       {report.passed}[/green]\n"
+            f"[red]Failed:       {report.failed}[/red]\n"
+            f"Not reviewed: {report.not_reviewed}",
+            title="Scan Complete",
+            border_style="#FF9010",
+        )
+    )
 
     if report.errors:
         rprint(f"\n[yellow]Errors ({len(report.errors)}):[/yellow]")
@@ -292,7 +293,4 @@ async def _results(system: str | None, control: str | None) -> None:
     passing = sum(1 for c in ccis if c["status"] == "pass")
     failing = sum(1 for c in ccis if c["status"] == "fail")
     not_tested = sum(1 for c in ccis if c["status"] == "not_tested")
-    rprint(
-        f"\n[dim]Summary: {passing} passing, {failing} failing, "
-        f"{not_tested} not tested ({total} total CCIs)[/dim]"
-    )
+    rprint(f"\n[dim]Summary: {passing} passing, {failing} failing, {not_tested} not tested ({total} total CCIs)[/dim]")

--- a/src/pretorin/cli/stig.py
+++ b/src/pretorin/cli/stig.py
@@ -21,7 +21,9 @@ app = typer.Typer(
 @app.command("list")
 def stig_list(
     technology_area: str | None = typer.Option(
-        None, "--technology-area", "-t",
+        None,
+        "--technology-area",
+        "-t",
         help="Filter by technology area (OS, Container, Database, etc.)",
     ),
     product: str | None = typer.Option(None, "--product", "-p", help="Filter by product name (partial match)"),
@@ -66,18 +68,14 @@ def stig_infer(
     asyncio.run(_infer(system))
 
 
-async def _list_stigs(
-    technology_area: str | None, product: str | None, limit: int
-) -> None:
+async def _list_stigs(technology_area: str | None, product: str | None, limit: int) -> None:
     from pretorin.cli.commands import require_auth
     from pretorin.client.api import PretorianClient, PretorianClientError
 
     async with PretorianClient() as client:
         require_auth(client)
         try:
-            data = await client.list_stigs(
-                technology_area=technology_area, product=product, limit=limit
-            )
+            data = await client.list_stigs(technology_area=technology_area, product=product, limit=limit)
         except PretorianClientError as e:
             rprint(f"[red]Error: {e.message}[/red]")
             raise typer.Exit(1)
@@ -156,18 +154,14 @@ async def _show_stig(stig_id: str) -> None:
     rprint(Panel(panel_content, title="STIG Benchmark", border_style="#FF9010"))
 
 
-async def _list_rules(
-    stig_id: str, severity: str | None, cci_id: str | None, limit: int
-) -> None:
+async def _list_rules(stig_id: str, severity: str | None, cci_id: str | None, limit: int) -> None:
     from pretorin.cli.commands import require_auth
     from pretorin.client.api import PretorianClient, PretorianClientError
 
     async with PretorianClient() as client:
         require_auth(client)
         try:
-            data = await client.list_stig_rules(
-                stig_id, severity=severity, cci_id=cci_id, limit=limit
-            )
+            data = await client.list_stig_rules(stig_id, severity=severity, cci_id=cci_id, limit=limit)
         except PretorianClientError as e:
             rprint(f"[red]Error: {e.message}[/red]")
             raise typer.Exit(1)
@@ -197,10 +191,9 @@ async def _list_rules(
             item.get("stig_ref", item.get("rule_id", ""))[:25],
             item.get("group_id", ""),
             (
-                f"[{severity_styles.get(sev, '')}]"
-                f"{sev.upper().replace('_', ' ')}"
-                f"[/{severity_styles.get(sev, '')}]"
-                if sev else ""
+                f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]"
+                if sev
+                else ""
             ),
             (item.get("title", "") or "")[:50],
             ", ".join(item.get("cci_ids", [])[:3]),
@@ -280,12 +273,13 @@ async def _infer(system: str | None) -> None:
         rprint("[dim]This may mean the system profile lacks tech stack details.[/dim]")
         return
 
-    rprint(Panel(
-        f"System: {data.get('system_name', data.get('system_id', ''))}\n"
-        f"Inferred: {len(inferred)} applicable STIGs",
-        title="STIG Inference Results",
-        border_style="#FF9010",
-    ))
+    rprint(
+        Panel(
+            f"System: {data.get('system_name', data.get('system_id', ''))}\nInferred: {len(inferred)} applicable STIGs",
+            title="STIG Inference Results",
+            border_style="#FF9010",
+        )
+    )
 
     table = Table()
     table.add_column("STIG", style="bold")

--- a/src/pretorin/cli/stig.py
+++ b/src/pretorin/cli/stig.py
@@ -1,0 +1,300 @@
+"""STIG browsing and applicability commands for Pretorin."""
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+from rich import print as rprint
+from rich.panel import Panel
+from rich.table import Table
+
+from pretorin.cli.output import is_json_mode, print_json
+
+app = typer.Typer(
+    name="stig",
+    help="Browse STIG benchmarks, rules, and applicability.",
+    no_args_is_help=True,
+)
+
+
+@app.command("list")
+def stig_list(
+    technology_area: str | None = typer.Option(None, "--technology-area", "-t", help="Filter by technology area (OS, Container, Database, etc.)"),
+    product: str | None = typer.Option(None, "--product", "-p", help="Filter by product name (partial match)"),
+    limit: int = typer.Option(100, "--limit", "-l", help="Max results"),
+) -> None:
+    """List all STIG benchmarks."""
+    asyncio.run(_list_stigs(technology_area, product, limit))
+
+
+@app.command("show")
+def stig_show(
+    stig_id: str = typer.Argument(..., help="STIG benchmark ID (e.g., RHEL_9_STIG)"),
+) -> None:
+    """Show STIG benchmark detail with severity breakdown."""
+    asyncio.run(_show_stig(stig_id))
+
+
+@app.command("rules")
+def stig_rules(
+    stig_id: str = typer.Argument(..., help="STIG benchmark ID"),
+    severity: str | None = typer.Option(None, "--severity", "-s", help="Filter: cat_i, cat_ii, cat_iii"),
+    cci_id: str | None = typer.Option(None, "--cci", help="Filter by CCI ID"),
+    limit: int = typer.Option(100, "--limit", "-l", help="Max results"),
+) -> None:
+    """List rules for a STIG benchmark."""
+    asyncio.run(_list_rules(stig_id, severity, cci_id, limit))
+
+
+@app.command("applicable")
+def stig_applicable(
+    system: str | None = typer.Option(None, "--system", "-s", help="System name or ID"),
+) -> None:
+    """Show applicable STIGs for the active system."""
+    asyncio.run(_applicable(system))
+
+
+@app.command("infer")
+def stig_infer(
+    system: str | None = typer.Option(None, "--system", "-s", help="System name or ID"),
+) -> None:
+    """AI-infer applicable STIGs based on system profile."""
+    asyncio.run(_infer(system))
+
+
+async def _list_stigs(
+    technology_area: str | None, product: str | None, limit: int
+) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            data = await client.list_stigs(
+                technology_area=technology_area, product=product, limit=limit
+            )
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    items = data.get("items", [])
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    if not items:
+        rprint("[dim]No STIG benchmarks found.[/dim]")
+        return
+
+    table = Table(title=f"STIG Benchmarks ({data.get('total', len(items))} total)")
+    table.add_column("STIG ID", style="bold")
+    table.add_column("Title")
+    table.add_column("Area", style="cyan")
+    table.add_column("Rules", justify="right")
+    table.add_column("CAT I", justify="right", style="red")
+    table.add_column("CAT II", justify="right", style="yellow")
+    table.add_column("CAT III", justify="right", style="green")
+
+    for item in items:
+        sc = item.get("severity_counts", {})
+        table.add_row(
+            item["stig_id"],
+            item.get("title", "")[:50],
+            item.get("technology_area", ""),
+            str(item.get("rule_count", 0)),
+            str(sc.get("cat_i", 0)),
+            str(sc.get("cat_ii", 0)),
+            str(sc.get("cat_iii", 0)),
+        )
+
+    rprint(table)
+
+
+async def _show_stig(stig_id: str) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            data = await client.list_stigs()
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    # Find matching STIG
+    items = data.get("items", [])
+    match = next((i for i in items if i["stig_id"] == stig_id), None)
+
+    if is_json_mode():
+        print_json(match or {"error": "not found"})
+        return
+
+    if not match:
+        rprint(f"[red]STIG {stig_id} not found[/red]")
+        raise typer.Exit(1)
+
+    sc = match.get("severity_counts", {})
+    panel_content = (
+        f"[bold]{match['title']}[/bold]\n\n"
+        f"STIG ID:     {match['stig_id']}\n"
+        f"Version:     {match.get('version', 'N/A')}\n"
+        f"Area:        {match.get('technology_area', 'N/A')}\n"
+        f"Product:     {match.get('product', 'N/A')}\n"
+        f"Vendor:      {match.get('vendor', 'N/A')}\n\n"
+        f"Total Rules: {match.get('rule_count', 0)}\n"
+        f"  [red]CAT I:   {sc.get('cat_i', 0)}[/red]\n"
+        f"  [yellow]CAT II:  {sc.get('cat_ii', 0)}[/yellow]\n"
+        f"  [green]CAT III: {sc.get('cat_iii', 0)}[/green]"
+    )
+    rprint(Panel(panel_content, title="STIG Benchmark", border_style="#FF9010"))
+
+
+async def _list_rules(
+    stig_id: str, severity: str | None, cci_id: str | None, limit: int
+) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            data = await client.list_stig_rules(
+                stig_id, severity=severity, cci_id=cci_id, limit=limit
+            )
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    items = data.get("items", [])
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    if not items:
+        rprint(f"[dim]No rules found for {stig_id}.[/dim]")
+        return
+
+    table = Table(title=f"{stig_id} Rules ({data.get('total', len(items))} total)")
+    table.add_column("Rule ID", style="bold")
+    table.add_column("V-ID")
+    table.add_column("Severity")
+    table.add_column("Title")
+    table.add_column("CCIs", style="dim")
+
+    severity_styles = {"cat_i": "red bold", "cat_ii": "yellow", "cat_iii": "green"}
+
+    for item in items:
+        sev = item.get("severity", "")
+        table.add_row(
+            item.get("stig_ref", item.get("rule_id", ""))[:25],
+            item.get("group_id", ""),
+            f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]" if sev else "",
+            (item.get("title", "") or "")[:50],
+            ", ".join(item.get("cci_ids", [])[:3]),
+        )
+
+    rprint(table)
+
+
+async def _applicable(system: str | None) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            system_id, _ = await resolve_execution_context(client, system=system)
+            data = await client.get_stig_applicability(system_id)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    items = data.get("applicability", [])
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    if not items:
+        rprint("[dim]No STIG applicability data for this system.[/dim]")
+        rprint("[dim]Run 'pretorin stig infer' to detect applicable STIGs.[/dim]")
+        return
+
+    table = Table(title="STIG Applicability")
+    table.add_column("STIG", style="bold")
+    table.add_column("Name")
+    table.add_column("Source")
+    table.add_column("Confidence", justify="right")
+    table.add_column("Status")
+
+    for item in items:
+        status = "✓ Confirmed" if item["is_confirmed"] else ("✗ Excluded" if item["is_excluded"] else "Pending")
+        style = "green" if item["is_confirmed"] else ("red" if item["is_excluded"] else "yellow")
+        conf = f"{item['confidence']:.0%}" if item.get("confidence") is not None else ""
+        table.add_row(
+            item["stig_id"],
+            item.get("stig_name", "")[:40],
+            item["source"],
+            conf,
+            f"[{style}]{status}[/{style}]",
+        )
+
+    rprint(table)
+
+
+async def _infer(system: str | None) -> None:
+    from pretorin.cli.commands import require_auth
+    from pretorin.cli.context import resolve_execution_context
+    from pretorin.client.api import PretorianClient, PretorianClientError
+
+    async with PretorianClient() as client:
+        require_auth(client)
+        try:
+            system_id, _ = await resolve_execution_context(client, system=system)
+            data = await client.infer_stigs(system_id)
+        except PretorianClientError as e:
+            rprint(f"[red]Error: {e.message}[/red]")
+            raise typer.Exit(1)
+
+    if is_json_mode():
+        print_json(data)
+        return
+
+    inferred = data.get("inferred", [])
+    if not inferred:
+        rprint("[dim]No applicable STIGs inferred for this system.[/dim]")
+        rprint("[dim]This may mean the system profile lacks tech stack details.[/dim]")
+        return
+
+    rprint(Panel(
+        f"System: {data.get('system_name', data.get('system_id', ''))}\n"
+        f"Inferred: {len(inferred)} applicable STIGs",
+        title="STIG Inference Results",
+        border_style="#FF9010",
+    ))
+
+    table = Table()
+    table.add_column("STIG", style="bold")
+    table.add_column("Name")
+    table.add_column("Area", style="cyan")
+    table.add_column("Confidence", justify="right")
+    table.add_column("Rationale", style="dim")
+
+    for item in inferred:
+        conf = item.get("confidence", 0)
+        conf_style = "green" if conf >= 0.7 else ("yellow" if conf >= 0.4 else "dim")
+        table.add_row(
+            item["stig_id"],
+            item.get("stig_name", "")[:35],
+            item.get("technology_area", ""),
+            f"[{conf_style}]{conf:.0%}[/{conf_style}]",
+            item.get("rationale", "")[:50],
+        )
+
+    rprint(table)

--- a/src/pretorin/cli/stig.py
+++ b/src/pretorin/cli/stig.py
@@ -20,7 +20,10 @@ app = typer.Typer(
 
 @app.command("list")
 def stig_list(
-    technology_area: str | None = typer.Option(None, "--technology-area", "-t", help="Filter by technology area (OS, Container, Database, etc.)"),
+    technology_area: str | None = typer.Option(
+        None, "--technology-area", "-t",
+        help="Filter by technology area (OS, Container, Database, etc.)",
+    ),
     product: str | None = typer.Option(None, "--product", "-p", help="Filter by product name (partial match)"),
     limit: int = typer.Option(100, "--limit", "-l", help="Max results"),
 ) -> None:
@@ -193,7 +196,12 @@ async def _list_rules(
         table.add_row(
             item.get("stig_ref", item.get("rule_id", ""))[:25],
             item.get("group_id", ""),
-            f"[{severity_styles.get(sev, '')}]{sev.upper().replace('_', ' ')}[/{severity_styles.get(sev, '')}]" if sev else "",
+            (
+                f"[{severity_styles.get(sev, '')}]"
+                f"{sev.upper().replace('_', ' ')}"
+                f"[/{severity_styles.get(sev, '')}]"
+                if sev else ""
+            ),
             (item.get("title", "") or "")[:50],
             ", ".join(item.get("cci_ids", [])[:3]),
         )

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -1288,3 +1288,109 @@ class PretorianClient:
             f"/systems/{system_id}/controls/{normalized}/responsibility/generate-narrative",
             params={"framework_id": framework_id},
         )
+
+    # -----------------------------------------------------------------
+    # DoD Traceability (CCI/STIG)
+    # -----------------------------------------------------------------
+
+    async def list_ccis(
+        self,
+        nist_control_id: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List CCI items with optional filters."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if nist_control_id:
+            params["nist_control_id"] = nist_control_id
+        if status:
+            params["status"] = status
+        return await self._request("GET", "/cci", params=params)
+
+    async def get_cci(self, cci_id: str) -> dict[str, Any]:
+        """Get CCI detail with linked SRGs and STIG rules."""
+        return await self._request("GET", f"/cci/{cci_id}")
+
+    async def list_stigs(
+        self,
+        technology_area: str | None = None,
+        product: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List STIG benchmarks."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if technology_area:
+            params["technology_area"] = technology_area
+        if product:
+            params["product"] = product
+        return await self._request("GET", "/stigs", params=params)
+
+    async def list_stig_rules(
+        self,
+        stig_id: str,
+        severity: str | None = None,
+        cci_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List rules for a STIG benchmark."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if severity:
+            params["severity"] = severity
+        if cci_id:
+            params["cci_id"] = cci_id
+        return await self._request("GET", f"/stigs/{stig_id}/rules", params=params)
+
+    async def get_stig_rule(self, stig_id: str, rule_id: str) -> dict[str, Any]:
+        """Get full detail for a single STIG rule."""
+        return await self._request("GET", f"/stigs/{stig_id}/rules/{rule_id}")
+
+    async def get_test_manifest(
+        self, system_id: str, stig_id: str | None = None
+    ) -> dict[str, Any]:
+        """Get test manifest for CLI scan execution."""
+        params = {"stig_id": stig_id} if stig_id else {}
+        return await self._request(
+            "GET", f"/systems/{system_id}/test-manifest", params=params
+        )
+
+    async def get_stig_applicability(self, system_id: str) -> dict[str, Any]:
+        """Get STIG applicability for a system."""
+        return await self._request(
+            "GET", f"/systems/{system_id}/stig-applicability"
+        )
+
+    async def submit_test_results(
+        self,
+        system_id: str,
+        cli_run_id: str,
+        results: list[dict[str, Any]],
+        cli_version: str | None = None,
+    ) -> dict[str, Any]:
+        """Submit STIG test results from a scan."""
+        return await self._request(
+            "POST",
+            f"/systems/{system_id}/test-results",
+            json={
+                "cli_run_id": cli_run_id,
+                "cli_version": cli_version,
+                "results": results,
+            },
+        )
+
+    async def get_cci_status(
+        self, system_id: str, nist_control_id: str | None = None
+    ) -> dict[str, Any]:
+        """Get CCI-level compliance status rollup for a system."""
+        params = {"nist_control_id": nist_control_id} if nist_control_id else {}
+        return await self._request(
+            "GET", f"/systems/{system_id}/cci-status", params=params
+        )
+
+    async def infer_stigs(self, system_id: str) -> dict[str, Any]:
+        """AI-infer applicable STIGs based on system profile."""
+        return await self._request(
+            "POST", f"/systems/{system_id}/infer-stigs"
+        )

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -1347,20 +1347,14 @@ class PretorianClient:
         """Get full detail for a single STIG rule."""
         return await self._request("GET", f"/stigs/{stig_id}/rules/{rule_id}")
 
-    async def get_test_manifest(
-        self, system_id: str, stig_id: str | None = None
-    ) -> dict[str, Any]:
+    async def get_test_manifest(self, system_id: str, stig_id: str | None = None) -> dict[str, Any]:
         """Get test manifest for CLI scan execution."""
         params = {"stig_id": stig_id} if stig_id else {}
-        return await self._request(
-            "GET", f"/systems/{system_id}/test-manifest", params=params
-        )
+        return await self._request("GET", f"/systems/{system_id}/test-manifest", params=params)
 
     async def get_stig_applicability(self, system_id: str) -> dict[str, Any]:
         """Get STIG applicability for a system."""
-        return await self._request(
-            "GET", f"/systems/{system_id}/stig-applicability"
-        )
+        return await self._request("GET", f"/systems/{system_id}/stig-applicability")
 
     async def submit_test_results(
         self,
@@ -1380,17 +1374,11 @@ class PretorianClient:
             },
         )
 
-    async def get_cci_status(
-        self, system_id: str, nist_control_id: str | None = None
-    ) -> dict[str, Any]:
+    async def get_cci_status(self, system_id: str, nist_control_id: str | None = None) -> dict[str, Any]:
         """Get CCI-level compliance status rollup for a system."""
         params = {"nist_control_id": nist_control_id} if nist_control_id else {}
-        return await self._request(
-            "GET", f"/systems/{system_id}/cci-status", params=params
-        )
+        return await self._request("GET", f"/systems/{system_id}/cci-status", params=params)
 
     async def infer_stigs(self, system_id: str) -> dict[str, Any]:
         """AI-infer applicable STIGs based on system profile."""
-        return await self._request(
-            "POST", f"/systems/{system_id}/infer-stigs"
-        )
+        return await self._request("POST", f"/systems/{system_id}/infer-stigs")

--- a/src/pretorin/scanners/__init__.py
+++ b/src/pretorin/scanners/__init__.py
@@ -1,0 +1,10 @@
+"""
+Scanner integrations for STIG compliance testing.
+
+Each scanner wraps an external tool (OpenSCAP, InSpec, cloud APIs) and
+produces standardized TestResult objects that map to STIG rules.
+"""
+
+from pretorin.scanners.base import ScannerBase, TestResult, ScannerInfo
+
+__all__ = ["ScannerBase", "TestResult", "ScannerInfo"]

--- a/src/pretorin/scanners/__init__.py
+++ b/src/pretorin/scanners/__init__.py
@@ -5,6 +5,6 @@ Each scanner wraps an external tool (OpenSCAP, InSpec, cloud APIs) and
 produces standardized TestResult objects that map to STIG rules.
 """
 
-from pretorin.scanners.base import ScannerBase, TestResult, ScannerInfo
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult
 
 __all__ = ["ScannerBase", "TestResult", "ScannerInfo"]

--- a/src/pretorin/scanners/base.py
+++ b/src/pretorin/scanners/base.py
@@ -1,0 +1,130 @@
+"""
+Abstract base for STIG compliance scanners.
+
+All scanners implement the same interface: detect availability, execute
+checks against STIG rules, and return standardized TestResult objects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class TestStatus(str, Enum):
+    """Outcome of a single STIG rule test."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_APPLICABLE = "not_applicable"
+    NOT_REVIEWED = "not_reviewed"
+    ERROR = "error"
+
+
+@dataclass
+class TestResult:
+    """Standardized result from evaluating one STIG rule."""
+
+    rule_id: str
+    benchmark_id: str  # STIG stig_id (e.g., "RHEL_9_STIG")
+    status: TestStatus
+    tested_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    tool: str = ""
+    tool_version: str = ""
+    tool_output: str = ""
+    evidence_id: str | None = None
+
+
+@dataclass
+class ScannerInfo:
+    """Metadata about an available scanner."""
+
+    name: str
+    version: str
+    available: bool
+    supported_stigs: list[str] = field(default_factory=list)
+    install_hint: str = ""
+
+
+class ScannerBase(ABC):
+    """
+    Abstract base class for STIG compliance scanners.
+
+    Subclasses wrap external tools (OpenSCAP, InSpec, cloud APIs) and
+    translate their output into standardized TestResult objects.
+    """
+
+    @abstractmethod
+    async def detect(self) -> ScannerInfo:
+        """
+        Check if this scanner's tooling is installed and available.
+
+        Returns:
+            ScannerInfo with availability status and version.
+        """
+        ...
+
+    @abstractmethod
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Run checks against a set of STIG rules.
+
+        Args:
+            rules: List of rule dicts from the test manifest (rule_id, check_text, etc.)
+            config: Scanner-specific configuration (profiles, targets, credentials)
+
+        Returns:
+            List of TestResult objects, one per rule evaluated.
+        """
+        ...
+
+    @abstractmethod
+    def supported_stigs(self) -> list[str]:
+        """
+        Which STIG benchmark IDs this scanner can evaluate.
+
+        Returns:
+            List of stig_id strings (e.g., ["RHEL_9_STIG", "RHEL_8_STIG"])
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable scanner name."""
+        ...
+
+    async def _run_command(
+        self, cmd: list[str], timeout: int = 300
+    ) -> tuple[int, str, str]:
+        """
+        Run a shell command asynchronously.
+
+        Returns (return_code, stdout, stderr).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+            return (
+                proc.returncode or 0,
+                stdout.decode("utf-8", errors="replace"),
+                stderr.decode("utf-8", errors="replace"),
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            return -1, "", f"Command timed out after {timeout}s"
+        except FileNotFoundError:
+            return -1, "", f"Command not found: {cmd[0]}"

--- a/src/pretorin/scanners/base.py
+++ b/src/pretorin/scanners/base.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Any
 
 
 class TestStatus(str, Enum):
@@ -70,8 +71,8 @@ class ScannerBase(ABC):
     @abstractmethod
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Run checks against a set of STIG rules.

--- a/src/pretorin/scanners/base.py
+++ b/src/pretorin/scanners/base.py
@@ -102,9 +102,7 @@ class ScannerBase(ABC):
         """Human-readable scanner name."""
         ...
 
-    async def _run_command(
-        self, cmd: list[str], timeout: int = 300
-    ) -> tuple[int, str, str]:
+    async def _run_command(self, cmd: list[str], timeout: int = 300) -> tuple[int, str, str]:
         """
         Run a shell command asynchronously.
 
@@ -116,9 +114,7 @@ class ScannerBase(ABC):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout
-            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             return (
                 proc.returncode or 0,
                 stdout.decode("utf-8", errors="replace"),

--- a/src/pretorin/scanners/cloud_aws.py
+++ b/src/pretorin/scanners/cloud_aws.py
@@ -1,0 +1,152 @@
+"""
+AWS cloud scanner integration.
+
+Queries AWS Security Hub findings and AWS Config compliance data to
+evaluate cloud-specific STIG rules. Maps Security Hub standard controls
+to STIG rule IDs via CCI references.
+
+Requires: AWS CLI v2 (aws binary) + configured credentials
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+class AWSCloudScanner(ScannerBase):
+    """AWS Security Hub / Config scanner."""
+
+    @property
+    def name(self) -> str:
+        return "cloud_aws"
+
+    def supported_stigs(self) -> list[str]:
+        return [
+            "Amazon_Elastic_Kubernetes_Service_EKS_STIG",
+        ]
+
+    async def detect(self) -> ScannerInfo:
+        """Check if AWS CLI is available and configured."""
+        code, stdout, stderr = await self._run_command(
+            ["aws", "--version"], timeout=10
+        )
+
+        if code != 0:
+            return ScannerInfo(
+                name=self.name,
+                version="",
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html",
+            )
+
+        version = stdout.strip().split()[0].replace("aws-cli/", "")
+
+        # Check if credentials are configured
+        code2, _, _ = await self._run_command(
+            ["aws", "sts", "get-caller-identity"], timeout=10
+        )
+        if code2 != 0:
+            return ScannerInfo(
+                name=self.name,
+                version=version,
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="AWS CLI installed but credentials not configured. Run: aws configure",
+            )
+
+        return ScannerInfo(
+            name=self.name,
+            version=version,
+            available=True,
+            supported_stigs=self.supported_stigs(),
+        )
+
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Query AWS Security Hub for STIG-mapped findings.
+
+        Config options:
+            region: AWS region (default: from AWS config)
+            account_id: AWS account ID to filter
+            benchmark_id: STIG benchmark ID for results
+        """
+        config = config or {}
+        benchmark_id = config.get("benchmark_id", "unknown")
+        region = config.get("region", "")
+
+        # Query Security Hub findings
+        cmd = [
+            "aws", "securityhub", "get-findings",
+            "--filters", json.dumps({
+                "ComplianceStatus": [{"Value": "PASSED", "Comparison": "EQUALS"}],
+                "RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}],
+            }),
+            "--max-items", "500",
+            "--output", "json",
+        ]
+        if region:
+            cmd.extend(["--region", region])
+
+        code, stdout, stderr = await self._run_command(cmd, timeout=60)
+
+        if code != 0:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output=f"AWS Security Hub query failed: {stderr[:1000]}",
+                )
+                for r in rules
+            ]
+
+        try:
+            findings_data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output="Failed to parse Security Hub response",
+                )
+                for r in rules
+            ]
+
+        # Build findings map by control ID
+        findings_map: dict[str, str] = {}
+        for finding in findings_data.get("Findings", []):
+            compliance = finding.get("Compliance", {})
+            status = compliance.get("Status", "")
+            # Security Hub control IDs may map to STIG rules via CCI
+            control_id = finding.get("ProductFields", {}).get("ControlId", "")
+            if control_id:
+                findings_map[control_id] = status
+
+        # Map findings to rules (best-effort matching via CCI cross-reference)
+        results = []
+        for rule in rules:
+            rule_id = rule.get("rule_id", "unknown")
+            # For now, mark as not_reviewed since direct mapping requires
+            # a CCI→SecurityHub control mapping table
+            results.append(
+                TestResult(
+                    rule_id=rule_id,
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.NOT_REVIEWED,
+                    tool=self.name,
+                    tool_output=f"Security Hub findings available: {len(findings_map)} controls",
+                )
+            )
+
+        return results

--- a/src/pretorin/scanners/cloud_aws.py
+++ b/src/pretorin/scanners/cloud_aws.py
@@ -11,7 +11,7 @@ Requires: AWS CLI v2 (aws binary) + configured credentials
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from typing import Any
 
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
@@ -67,8 +67,8 @@ class AWSCloudScanner(ScannerBase):
 
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Query AWS Security Hub for STIG-mapped findings.

--- a/src/pretorin/scanners/cloud_aws.py
+++ b/src/pretorin/scanners/cloud_aws.py
@@ -30,9 +30,7 @@ class AWSCloudScanner(ScannerBase):
 
     async def detect(self) -> ScannerInfo:
         """Check if AWS CLI is available and configured."""
-        code, stdout, stderr = await self._run_command(
-            ["aws", "--version"], timeout=10
-        )
+        code, stdout, stderr = await self._run_command(["aws", "--version"], timeout=10)
 
         if code != 0:
             return ScannerInfo(
@@ -46,9 +44,7 @@ class AWSCloudScanner(ScannerBase):
         version = stdout.strip().split()[0].replace("aws-cli/", "")
 
         # Check if credentials are configured
-        code2, _, _ = await self._run_command(
-            ["aws", "sts", "get-caller-identity"], timeout=10
-        )
+        code2, _, _ = await self._run_command(["aws", "sts", "get-caller-identity"], timeout=10)
         if code2 != 0:
             return ScannerInfo(
                 name=self.name,
@@ -84,13 +80,20 @@ class AWSCloudScanner(ScannerBase):
 
         # Query Security Hub findings
         cmd = [
-            "aws", "securityhub", "get-findings",
-            "--filters", json.dumps({
-                "ComplianceStatus": [{"Value": "PASSED", "Comparison": "EQUALS"}],
-                "RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}],
-            }),
-            "--max-items", "500",
-            "--output", "json",
+            "aws",
+            "securityhub",
+            "get-findings",
+            "--filters",
+            json.dumps(
+                {
+                    "ComplianceStatus": [{"Value": "PASSED", "Comparison": "EQUALS"}],
+                    "RecordState": [{"Value": "ACTIVE", "Comparison": "EQUALS"}],
+                }
+            ),
+            "--max-items",
+            "500",
+            "--output",
+            "json",
         ]
         if region:
             cmd.extend(["--region", region])

--- a/src/pretorin/scanners/cloud_azure.py
+++ b/src/pretorin/scanners/cloud_azure.py
@@ -1,0 +1,121 @@
+"""
+Azure cloud scanner integration.
+
+Queries Azure Policy compliance state and Microsoft Defender for Cloud
+to evaluate cloud-specific STIG rules.
+
+Requires: Azure CLI (az binary) + authenticated session
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+class AzureCloudScanner(ScannerBase):
+    """Azure Policy / Defender for Cloud scanner."""
+
+    @property
+    def name(self) -> str:
+        return "cloud_azure"
+
+    def supported_stigs(self) -> list[str]:
+        return [
+            "Microsoft_Azure_Foundations_STIG",
+        ]
+
+    async def detect(self) -> ScannerInfo:
+        """Check if Azure CLI is available and authenticated."""
+        code, stdout, stderr = await self._run_command(
+            ["az", "version", "--output", "json"], timeout=10
+        )
+
+        if code != 0:
+            return ScannerInfo(
+                name=self.name,
+                version="",
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="Install: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli",
+            )
+
+        try:
+            version_data = json.loads(stdout)
+            version = version_data.get("azure-cli", "")
+        except json.JSONDecodeError:
+            version = ""
+
+        # Check if logged in
+        code2, _, _ = await self._run_command(
+            ["az", "account", "show", "--output", "json"], timeout=10
+        )
+        if code2 != 0:
+            return ScannerInfo(
+                name=self.name,
+                version=version,
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="Azure CLI installed but not authenticated. Run: az login",
+            )
+
+        return ScannerInfo(
+            name=self.name,
+            version=version,
+            available=True,
+            supported_stigs=self.supported_stigs(),
+        )
+
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Query Azure Policy compliance for STIG-mapped rules.
+
+        Config options:
+            subscription_id: Azure subscription ID
+            benchmark_id: STIG benchmark ID for results
+        """
+        config = config or {}
+        benchmark_id = config.get("benchmark_id", "unknown")
+        subscription = config.get("subscription_id", "")
+
+        cmd = [
+            "az", "policy", "state", "summarize",
+            "--output", "json",
+        ]
+        if subscription:
+            cmd.extend(["--subscription", subscription])
+
+        code, stdout, stderr = await self._run_command(cmd, timeout=60)
+
+        if code != 0:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output=f"Azure Policy query failed: {stderr[:1000]}",
+                )
+                for r in rules
+            ]
+
+        # Map policy compliance to STIG rules (best-effort)
+        results = []
+        for rule in rules:
+            results.append(
+                TestResult(
+                    rule_id=rule.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.NOT_REVIEWED,
+                    tool=self.name,
+                    tool_output="Azure Policy compliance data available — rule mapping pending",
+                )
+            )
+
+        return results

--- a/src/pretorin/scanners/cloud_azure.py
+++ b/src/pretorin/scanners/cloud_azure.py
@@ -29,9 +29,7 @@ class AzureCloudScanner(ScannerBase):
 
     async def detect(self) -> ScannerInfo:
         """Check if Azure CLI is available and authenticated."""
-        code, stdout, stderr = await self._run_command(
-            ["az", "version", "--output", "json"], timeout=10
-        )
+        code, stdout, stderr = await self._run_command(["az", "version", "--output", "json"], timeout=10)
 
         if code != 0:
             return ScannerInfo(
@@ -49,9 +47,7 @@ class AzureCloudScanner(ScannerBase):
             version = ""
 
         # Check if logged in
-        code2, _, _ = await self._run_command(
-            ["az", "account", "show", "--output", "json"], timeout=10
-        )
+        code2, _, _ = await self._run_command(["az", "account", "show", "--output", "json"], timeout=10)
         if code2 != 0:
             return ScannerInfo(
                 name=self.name,
@@ -85,8 +81,12 @@ class AzureCloudScanner(ScannerBase):
         subscription = config.get("subscription_id", "")
 
         cmd = [
-            "az", "policy", "state", "summarize",
-            "--output", "json",
+            "az",
+            "policy",
+            "state",
+            "summarize",
+            "--output",
+            "json",
         ]
         if subscription:
             cmd.extend(["--subscription", subscription])

--- a/src/pretorin/scanners/cloud_azure.py
+++ b/src/pretorin/scanners/cloud_azure.py
@@ -10,7 +10,7 @@ Requires: Azure CLI (az binary) + authenticated session
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from typing import Any
 
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
@@ -70,8 +70,8 @@ class AzureCloudScanner(ScannerBase):
 
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Query Azure Policy compliance for STIG-mapped rules.

--- a/src/pretorin/scanners/inspec.py
+++ b/src/pretorin/scanners/inspec.py
@@ -44,9 +44,7 @@ class InSpecScanner(ScannerBase):
 
     async def detect(self) -> ScannerInfo:
         """Check if inspec binary is available."""
-        code, stdout, stderr = await self._run_command(
-            ["inspec", "version"], timeout=15
-        )
+        code, stdout, stderr = await self._run_command(["inspec", "version"], timeout=15)
 
         if code != 0:
             return ScannerInfo(
@@ -102,8 +100,11 @@ class InSpecScanner(ScannerBase):
             results_path = tf.name
 
         cmd = [
-            "inspec", "exec", str(profile),
-            "--reporter", f"json:{results_path}",
+            "inspec",
+            "exec",
+            str(profile),
+            "--reporter",
+            f"json:{results_path}",
         ]
 
         target = config.get("target")
@@ -129,9 +130,7 @@ class InSpecScanner(ScannerBase):
                 for r in rules
             ]
 
-        return self._parse_json_results(
-            Path(results_path), benchmark_id, rules
-        )
+        return self._parse_json_results(Path(results_path), benchmark_id, rules)
 
     def _parse_json_results(
         self, results_path: Path, benchmark_id: str, rules: list[dict[str, Any]]

--- a/src/pretorin/scanners/inspec.py
+++ b/src/pretorin/scanners/inspec.py
@@ -1,0 +1,207 @@
+"""
+Chef InSpec / MITRE SAF scanner integration.
+
+Wraps `inspec exec` to run MITRE SAF STIG InSpec profiles and parses
+the JSON output into standardized TestResult objects.
+
+Requires: Chef InSpec (inspec binary)
+Profiles: MITRE SAF InSpec profiles (https://github.com/mitre/)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+class InSpecScanner(ScannerBase):
+    """Chef InSpec / MITRE SAF scanner."""
+
+    @property
+    def name(self) -> str:
+        return "inspec"
+
+    def supported_stigs(self) -> list[str]:
+        # InSpec MITRE SAF profiles cover a wide range
+        return [
+            "RHEL_9_STIG",
+            "RHEL_8_STIG",
+            "RHEL_7_STIG",
+            "CAN_Ubuntu_22-04_LTS_STIG",
+            "CAN_Ubuntu_20-04_LTS_STIG",
+            "MS_Windows_Server_2022_STIG",
+            "MS_Windows_Server_2019_STIG",
+            "Kubernetes_STIG",
+            "PostgreSQL_9-x_STIG",
+            "NGINX_STIG",
+            "Apache_Server_2-4_UNIX_STIG",
+        ]
+
+    async def detect(self) -> ScannerInfo:
+        """Check if inspec binary is available."""
+        code, stdout, stderr = await self._run_command(
+            ["inspec", "version"], timeout=15
+        )
+
+        if code != 0:
+            return ScannerInfo(
+                name=self.name,
+                version="",
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="Install: curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P inspec",
+            )
+
+        version = stdout.strip().split("\n")[0]
+
+        return ScannerInfo(
+            name=self.name,
+            version=version,
+            available=True,
+            supported_stigs=self.supported_stigs(),
+        )
+
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Run inspec exec against a MITRE SAF profile.
+
+        Config options:
+            profile: Path or URL to InSpec profile (required)
+            target: Target connection string (e.g., "ssh://user@host")
+            reporter: Output format (default: json)
+            benchmark_id: STIG benchmark ID for results
+            attrs: Path to attributes YAML file
+        """
+        config = config or {}
+        profile = config.get("profile")
+        benchmark_id = config.get("benchmark_id", "unknown")
+
+        if not profile:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output="No profile provided in scanner config",
+                )
+                for r in rules
+            ]
+
+        # Build inspec command with JSON reporter
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+            results_path = tf.name
+
+        cmd = [
+            "inspec", "exec", str(profile),
+            "--reporter", f"json:{results_path}",
+        ]
+
+        target = config.get("target")
+        if target:
+            cmd.extend(["--target", target])
+
+        attrs = config.get("attrs")
+        if attrs:
+            cmd.extend(["--attrs", str(attrs)])
+
+        # InSpec returns 0=pass, 100=has-failures, 101=profile-error
+        code, stdout, stderr = await self._run_command(cmd, timeout=600)
+
+        if code == 101:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output=f"InSpec profile error: {stderr[:2000]}",
+                )
+                for r in rules
+            ]
+
+        return self._parse_json_results(
+            Path(results_path), benchmark_id, rules
+        )
+
+    def _parse_json_results(
+        self, results_path: Path, benchmark_id: str, rules: list[dict]
+    ) -> list[TestResult]:
+        """Parse InSpec JSON output into TestResult objects."""
+        if not results_path.exists():
+            return []
+
+        try:
+            with open(results_path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return []
+
+        # Build rule_id lookup — InSpec control IDs may match V-IDs or SV-IDs
+        rule_lookup: dict[str, str] = {}
+        for r in rules:
+            rule_lookup[r.get("rule_id", "")] = r.get("rule_id", "")
+            if r.get("group_id"):
+                rule_lookup[r["group_id"]] = r.get("rule_id", "")
+
+        results = []
+        profiles = data.get("profiles", [])
+
+        for profile in profiles:
+            for control in profile.get("controls", []):
+                control_id = control.get("id", "")
+
+                # Match to our rule IDs
+                matched_rule_id = rule_lookup.get(control_id)
+                if not matched_rule_id:
+                    # Try matching by stripping version suffix
+                    base_id = re.sub(r"r\d+_rule$", "", control_id)
+                    matched_rule_id = rule_lookup.get(base_id)
+                if not matched_rule_id:
+                    continue
+
+                # Aggregate control results
+                control_results = control.get("results", [])
+                if not control_results:
+                    status = TestStatus.NOT_REVIEWED
+                    output = ""
+                else:
+                    statuses = [cr.get("status", "") for cr in control_results]
+                    if "failed" in statuses:
+                        status = TestStatus.FAIL
+                    elif all(s == "passed" for s in statuses):
+                        status = TestStatus.PASS
+                    elif all(s == "skipped" for s in statuses):
+                        status = TestStatus.NOT_APPLICABLE
+                    else:
+                        status = TestStatus.FAIL
+
+                    # Collect output messages
+                    messages = []
+                    for cr in control_results:
+                        if cr.get("message"):
+                            messages.append(cr["message"])
+                        elif cr.get("skip_message"):
+                            messages.append(f"SKIP: {cr['skip_message']}")
+                    output = "\n".join(messages)[:5000]
+
+                results.append(
+                    TestResult(
+                        rule_id=matched_rule_id,
+                        benchmark_id=benchmark_id,
+                        status=status,
+                        tool=self.name,
+                        tool_output=output,
+                    )
+                )
+
+        return results

--- a/src/pretorin/scanners/inspec.py
+++ b/src/pretorin/scanners/inspec.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import json
 import re
 import tempfile
-from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
@@ -68,8 +68,8 @@ class InSpecScanner(ScannerBase):
 
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Run inspec exec against a MITRE SAF profile.
@@ -134,7 +134,7 @@ class InSpecScanner(ScannerBase):
         )
 
     def _parse_json_results(
-        self, results_path: Path, benchmark_id: str, rules: list[dict]
+        self, results_path: Path, benchmark_id: str, rules: list[dict[str, Any]]
     ) -> list[TestResult]:
         """Parse InSpec JSON output into TestResult objects."""
         if not results_path.exists():

--- a/src/pretorin/scanners/manual.py
+++ b/src/pretorin/scanners/manual.py
@@ -1,0 +1,132 @@
+"""
+Manual check scanner — for rules that require human verification.
+
+Presents check text to the user and collects pass/fail/N/A responses
+interactively. Used for policy-type CCIs and rules without automated
+OVAL/InSpec checks.
+"""
+
+from __future__ import annotations
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+class ManualScanner(ScannerBase):
+    """Interactive manual check handler."""
+
+    @property
+    def name(self) -> str:
+        return "manual"
+
+    def supported_stigs(self) -> list[str]:
+        # Manual scanner handles any STIG — it's the fallback
+        return ["*"]
+
+    async def detect(self) -> ScannerInfo:
+        """Manual scanner is always available."""
+        return ScannerInfo(
+            name=self.name,
+            version="1.0",
+            available=True,
+            supported_stigs=self.supported_stigs(),
+        )
+
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Collect manual check results.
+
+        In interactive mode, prompts the user for each rule.
+        In batch mode (config.batch=True), marks all as not_reviewed.
+
+        Config options:
+            batch: If True, skip prompts and mark all as not_reviewed
+            benchmark_id: STIG benchmark ID for results
+            responses: Pre-filled dict of rule_id → status for non-interactive use
+        """
+        config = config or {}
+        benchmark_id = config.get("benchmark_id", "unknown")
+        batch_mode = config.get("batch", False)
+        pre_responses = config.get("responses", {})
+
+        results = []
+        for rule in rules:
+            rule_id = rule.get("rule_id", "unknown")
+
+            # Check for pre-filled response
+            if rule_id in pre_responses:
+                status_str = pre_responses[rule_id].lower()
+                status_map = {
+                    "pass": TestStatus.PASS,
+                    "fail": TestStatus.FAIL,
+                    "na": TestStatus.NOT_APPLICABLE,
+                    "not_applicable": TestStatus.NOT_APPLICABLE,
+                    "skip": TestStatus.NOT_REVIEWED,
+                }
+                status = status_map.get(status_str, TestStatus.NOT_REVIEWED)
+                results.append(
+                    TestResult(
+                        rule_id=rule_id,
+                        benchmark_id=benchmark_id,
+                        status=status,
+                        tool=self.name,
+                        tool_output=f"Manual response: {status_str}",
+                    )
+                )
+                continue
+
+            if batch_mode:
+                results.append(
+                    TestResult(
+                        rule_id=rule_id,
+                        benchmark_id=benchmark_id,
+                        status=TestStatus.NOT_REVIEWED,
+                        tool=self.name,
+                        tool_output="Batch mode — requires manual review",
+                    )
+                )
+                continue
+
+            # Interactive prompt
+            title = rule.get("title", "")
+            check_text = rule.get("check_text", "No check text available")
+
+            print(f"\n{'='*60}")
+            print(f"Rule: {rule_id}")
+            if title:
+                print(f"Title: {title}")
+            print(f"Severity: {rule.get('severity', 'unknown')}")
+            print(f"\nCheck:\n{check_text[:500]}")
+            print(f"{'='*60}")
+
+            while True:
+                response = input("[P]ass / [F]ail / [N/A] / [S]kip > ").strip().lower()
+                if response in ("p", "pass"):
+                    status = TestStatus.PASS
+                    break
+                elif response in ("f", "fail"):
+                    status = TestStatus.FAIL
+                    break
+                elif response in ("n", "na", "n/a", "not_applicable"):
+                    status = TestStatus.NOT_APPLICABLE
+                    break
+                elif response in ("s", "skip", ""):
+                    status = TestStatus.NOT_REVIEWED
+                    break
+                else:
+                    print("Invalid input. Enter P, F, N/A, or S.")
+
+            results.append(
+                TestResult(
+                    rule_id=rule_id,
+                    benchmark_id=benchmark_id,
+                    status=status,
+                    tool=self.name,
+                    tool_output=f"Manual assessment: {status.value}",
+                )
+            )
+
+        return results

--- a/src/pretorin/scanners/manual.py
+++ b/src/pretorin/scanners/manual.py
@@ -96,13 +96,13 @@ class ManualScanner(ScannerBase):
             title = rule.get("title", "")
             check_text = rule.get("check_text", "No check text available")
 
-            print(f"\n{'='*60}")
+            print(f"\n{'=' * 60}")
             print(f"Rule: {rule_id}")
             if title:
                 print(f"Title: {title}")
             print(f"Severity: {rule.get('severity', 'unknown')}")
             print(f"\nCheck:\n{check_text[:500]}")
-            print(f"{'='*60}")
+            print(f"{'=' * 60}")
 
             while True:
                 response = input("[P]ass / [F]ail / [N/A] / [S]kip > ").strip().lower()

--- a/src/pretorin/scanners/manual.py
+++ b/src/pretorin/scanners/manual.py
@@ -8,6 +8,8 @@ OVAL/InSpec checks.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
 
@@ -33,8 +35,8 @@ class ManualScanner(ScannerBase):
 
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Collect manual check results.

--- a/src/pretorin/scanners/openscap.py
+++ b/src/pretorin/scanners/openscap.py
@@ -1,0 +1,187 @@
+"""
+OpenSCAP scanner integration.
+
+Wraps `oscap xccdf eval` to run DISA STIG profiles and parses the
+XCCDF results XML into standardized TestResult objects.
+
+Requires: openscap-scanner package (oscap binary)
+STIG profiles: DISA STIG XCCDF files with profiles defined
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+class OpenSCAPScanner(ScannerBase):
+    """OpenSCAP XCCDF evaluation scanner."""
+
+    @property
+    def name(self) -> str:
+        return "openscap"
+
+    def supported_stigs(self) -> list[str]:
+        # OpenSCAP handles any XCCDF-based STIG
+        return [
+            "RHEL_9_STIG",
+            "RHEL_8_STIG",
+            "RHEL_7_STIG",
+            "CAN_Ubuntu_22-04_LTS_STIG",
+            "CAN_Ubuntu_20-04_LTS_STIG",
+            "SLES_15_STIG",
+        ]
+
+    async def detect(self) -> ScannerInfo:
+        """Check if oscap binary is available."""
+        code, stdout, stderr = await self._run_command(["oscap", "--version"], timeout=10)
+
+        if code != 0:
+            return ScannerInfo(
+                name=self.name,
+                version="",
+                available=False,
+                supported_stigs=self.supported_stigs(),
+                install_hint="Install: sudo dnf install openscap-scanner (RHEL/Fedora) or sudo apt install libopenscap8 (Debian/Ubuntu)",
+            )
+
+        # Parse version from output like "OpenSCAP command line tool (oscap) 1.3.7"
+        version = ""
+        match = re.search(r"oscap\)\s+([\d.]+)", stdout)
+        if match:
+            version = match.group(1)
+
+        return ScannerInfo(
+            name=self.name,
+            version=version,
+            available=True,
+            supported_stigs=self.supported_stigs(),
+        )
+
+    async def execute(
+        self,
+        rules: list[dict],
+        config: dict | None = None,
+    ) -> list[TestResult]:
+        """
+        Run oscap xccdf eval against a STIG profile.
+
+        Config options:
+            xccdf_path: Path to STIG XCCDF file (required)
+            profile: XCCDF profile ID to evaluate (default: auto-detect)
+            target: Remote target (default: localhost)
+            results_path: Where to write results XML (default: temp file)
+        """
+        config = config or {}
+        xccdf_path = config.get("xccdf_path")
+        if not xccdf_path:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=config.get("benchmark_id", "unknown"),
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output="No xccdf_path provided in scanner config",
+                )
+                for r in rules
+            ]
+
+        profile = config.get("profile", "")
+        benchmark_id = config.get("benchmark_id", "unknown")
+        results_path = config.get("results_path", "/tmp/oscap-results.xml")
+
+        # Build oscap command
+        cmd = [
+            "oscap", "xccdf", "eval",
+            "--results", results_path,
+        ]
+        if profile:
+            cmd.extend(["--profile", profile])
+        cmd.append(str(xccdf_path))
+
+        # Run evaluation
+        code, stdout, stderr = await self._run_command(cmd, timeout=600)
+
+        # oscap returns 0 for all-pass, 2 for some-fail, 1 for error
+        if code == 1 and "Error" in stderr:
+            return [
+                TestResult(
+                    rule_id=r.get("rule_id", "unknown"),
+                    benchmark_id=benchmark_id,
+                    status=TestStatus.ERROR,
+                    tool=self.name,
+                    tool_output=f"oscap error: {stderr[:2000]}",
+                )
+                for r in rules
+            ]
+
+        # Parse results XML
+        return self._parse_results_xml(
+            Path(results_path), benchmark_id, rules
+        )
+
+    def _parse_results_xml(
+        self, results_path: Path, benchmark_id: str, rules: list[dict]
+    ) -> list[TestResult]:
+        """Parse XCCDF results XML into TestResult objects."""
+        if not results_path.exists():
+            return []
+
+        try:
+            tree = ET.parse(results_path)
+        except ET.ParseError:
+            return []
+
+        root = tree.getroot()
+        ns_match = re.match(r"\{(.+?)\}", root.tag)
+        ns = ns_match.group(1) if ns_match else ""
+
+        # Build rule_id set for filtering
+        rule_id_set = {r.get("rule_id") for r in rules}
+
+        results = []
+        # Find all rule-result elements
+        for rr in root.iter(f"{{{ns}}}rule-result" if ns else "rule-result"):
+            rule_id = rr.get("idref", "")
+            if rule_id not in rule_id_set:
+                continue
+
+            result_el = rr.find(f"{{{ns}}}result" if ns else "result")
+            result_text = result_el.text.strip() if result_el is not None and result_el.text else "unknown"
+
+            # Map XCCDF result to our status
+            status_map = {
+                "pass": TestStatus.PASS,
+                "fail": TestStatus.FAIL,
+                "notapplicable": TestStatus.NOT_APPLICABLE,
+                "notchecked": TestStatus.NOT_REVIEWED,
+                "informational": TestStatus.NOT_REVIEWED,
+                "error": TestStatus.ERROR,
+                "unknown": TestStatus.NOT_REVIEWED,
+                "notselected": TestStatus.NOT_APPLICABLE,
+            }
+            status = status_map.get(result_text.lower(), TestStatus.ERROR)
+
+            # Extract check output if present
+            check_el = rr.find(f".//{{{ns}}}check" if ns else ".//check")
+            output = ""
+            if check_el is not None:
+                msg_el = check_el.find(f"{{{ns}}}message" if ns else "message")
+                if msg_el is not None and msg_el.text:
+                    output = msg_el.text.strip()[:5000]
+
+            results.append(
+                TestResult(
+                    rule_id=rule_id,
+                    benchmark_id=benchmark_id,
+                    status=status,
+                    tool=self.name,
+                    tool_output=output,
+                )
+            )
+
+        return results

--- a/src/pretorin/scanners/openscap.py
+++ b/src/pretorin/scanners/openscap.py
@@ -99,8 +99,11 @@ class OpenSCAPScanner(ScannerBase):
 
         # Build oscap command
         cmd = [
-            "oscap", "xccdf", "eval",
-            "--results", results_path,
+            "oscap",
+            "xccdf",
+            "eval",
+            "--results",
+            results_path,
         ]
         if profile:
             cmd.extend(["--profile", profile])
@@ -123,9 +126,7 @@ class OpenSCAPScanner(ScannerBase):
             ]
 
         # Parse results XML
-        return self._parse_results_xml(
-            Path(results_path), benchmark_id, rules
-        )
+        return self._parse_results_xml(Path(results_path), benchmark_id, rules)
 
     def _parse_results_xml(
         self, results_path: Path, benchmark_id: str, rules: list[dict[str, Any]]

--- a/src/pretorin/scanners/openscap.py
+++ b/src/pretorin/scanners/openscap.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
@@ -46,7 +46,10 @@ class OpenSCAPScanner(ScannerBase):
                 version="",
                 available=False,
                 supported_stigs=self.supported_stigs(),
-                install_hint="Install: sudo dnf install openscap-scanner (RHEL/Fedora) or sudo apt install libopenscap8 (Debian/Ubuntu)",
+                install_hint=(
+                    "Install: sudo dnf install openscap-scanner (RHEL/Fedora)"
+                    " or sudo apt install libopenscap8 (Debian/Ubuntu)"
+                ),
             )
 
         # Parse version from output like "OpenSCAP command line tool (oscap) 1.3.7"
@@ -64,8 +67,8 @@ class OpenSCAPScanner(ScannerBase):
 
     async def execute(
         self,
-        rules: list[dict],
-        config: dict | None = None,
+        rules: list[dict[str, Any]],
+        config: dict[str, Any] | None = None,
     ) -> list[TestResult]:
         """
         Run oscap xccdf eval against a STIG profile.
@@ -125,7 +128,7 @@ class OpenSCAPScanner(ScannerBase):
         )
 
     def _parse_results_xml(
-        self, results_path: Path, benchmark_id: str, rules: list[dict]
+        self, results_path: Path, benchmark_id: str, rules: list[dict[str, Any]]
     ) -> list[TestResult]:
         """Parse XCCDF results XML into TestResult objects."""
         if not results_path.exists():

--- a/src/pretorin/scanners/orchestrator.py
+++ b/src/pretorin/scanners/orchestrator.py
@@ -188,9 +188,7 @@ class ScanOrchestrator:
                 results = await scanner.execute(step.rules, step.config)
                 report.results.extend(results)
             except Exception as e:
-                report.errors.append(
-                    f"Scanner {step.scanner_name} failed for {step.benchmark_id}: {e}"
-                )
+                report.errors.append(f"Scanner {step.scanner_name} failed for {step.benchmark_id}: {e}")
                 # Mark rules as error
                 for rule in step.rules:
                     report.results.append(
@@ -208,7 +206,7 @@ class ScanOrchestrator:
 
     async def run(
         self,
-        client,  # PretorianClient
+        client: Any,  # PretorianClient
         system_id: str,
         stig_id: str | None = None,
         preferred_scanner: str | None = None,

--- a/src/pretorin/scanners/orchestrator.py
+++ b/src/pretorin/scanners/orchestrator.py
@@ -1,0 +1,284 @@
+"""
+Scan orchestrator — coordinates scanner execution for STIG compliance testing.
+
+1. Pulls test manifest from Pretorin API (applicable STIGs + rules)
+2. Detects available scanner tools (OpenSCAP, InSpec, cloud CLIs)
+3. Plans which scanners to run for which STIG rules
+4. Executes scanners and collects results
+5. Uploads results to Pretorin
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
+
+
+@dataclass
+class ScanPlanStep:
+    """One step in the scan plan: a scanner + its assigned rules."""
+
+    scanner_name: str
+    benchmark_id: str
+    rules: list[dict]
+    config: dict = field(default_factory=dict)
+
+
+@dataclass
+class ScanPlan:
+    """Full scan execution plan."""
+
+    steps: list[ScanPlanStep]
+    unassigned_rules: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class ScanReport:
+    """Results from a complete scan run."""
+
+    cli_run_id: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    results: list[TestResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.results)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for r in self.results if r.status == TestStatus.PASS)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.results if r.status == TestStatus.FAIL)
+
+    @property
+    def not_reviewed(self) -> int:
+        return sum(1 for r in self.results if r.status == TestStatus.NOT_REVIEWED)
+
+
+class ScanOrchestrator:
+    """
+    Orchestrates STIG compliance scanning.
+
+    Manages scanner detection, test planning, execution, and result
+    submission to the Pretorin platform.
+    """
+
+    def __init__(self, scanners: list[ScannerBase] | None = None):
+        if scanners is None:
+            scanners = self._default_scanners()
+        self._scanners = scanners
+        self._scanner_info: dict[str, ScannerInfo] = {}
+
+    @staticmethod
+    def _default_scanners() -> list[ScannerBase]:
+        """Create default set of all available scanners."""
+        from pretorin.scanners.cloud_aws import AWSCloudScanner
+        from pretorin.scanners.cloud_azure import AzureCloudScanner
+        from pretorin.scanners.inspec import InSpecScanner
+        from pretorin.scanners.manual import ManualScanner
+        from pretorin.scanners.openscap import OpenSCAPScanner
+
+        return [
+            OpenSCAPScanner(),
+            InSpecScanner(),
+            AWSCloudScanner(),
+            AzureCloudScanner(),
+            ManualScanner(),
+        ]
+
+    async def detect_scanners(self) -> list[ScannerInfo]:
+        """Detect which scanners are available on this system."""
+        infos = []
+        for scanner in self._scanners:
+            info = await scanner.detect()
+            self._scanner_info[scanner.name] = info
+            infos.append(info)
+        return infos
+
+    def plan_scan(
+        self,
+        manifest: dict,
+        scanner_config: dict | None = None,
+        preferred_scanner: str | None = None,
+    ) -> ScanPlan:
+        """
+        Create a scan plan from a test manifest.
+
+        Assigns rules to available scanners based on STIG compatibility.
+        Rules with no matching scanner go to unassigned (require manual review).
+        """
+        scanner_config = scanner_config or {}
+        steps: list[ScanPlanStep] = []
+        unassigned: list[dict] = []
+
+        # Build scanner lookup: name → (scanner, info)
+        available = {
+            s.name: s
+            for s in self._scanners
+            if self._scanner_info.get(s.name, ScannerInfo(name=s.name, version="", available=False)).available
+        }
+
+        for stig in manifest.get("applicable_stigs", []):
+            stig_id = stig["stig_id"]
+            rules = stig.get("rules", [])
+            if not rules:
+                continue
+
+            # Find best scanner for this STIG
+            assigned_scanner = None
+
+            if preferred_scanner and preferred_scanner in available:
+                scanner = available[preferred_scanner]
+                if stig_id in scanner.supported_stigs() or "*" in scanner.supported_stigs():
+                    assigned_scanner = preferred_scanner
+
+            if not assigned_scanner:
+                for name, scanner in available.items():
+                    if name == "manual":
+                        continue  # Manual is fallback only
+                    supported = scanner.supported_stigs()
+                    if stig_id in supported or "*" in supported:
+                        assigned_scanner = name
+                        break
+
+            if assigned_scanner:
+                config = scanner_config.get(assigned_scanner, {})
+                config["benchmark_id"] = stig_id
+                steps.append(
+                    ScanPlanStep(
+                        scanner_name=assigned_scanner,
+                        benchmark_id=stig_id,
+                        rules=rules,
+                        config=config,
+                    )
+                )
+            else:
+                # No automated scanner — add to unassigned for manual review
+                for rule in rules:
+                    rule["_benchmark_id"] = stig_id
+                unassigned.extend(rules)
+
+        return ScanPlan(steps=steps, unassigned_rules=unassigned)
+
+    async def execute_plan(self, plan: ScanPlan) -> ScanReport:
+        """Execute a scan plan and collect results."""
+        cli_run_id = str(uuid.uuid4())[:8]
+        report = ScanReport(
+            cli_run_id=cli_run_id,
+            started_at=datetime.now(timezone.utc),
+        )
+
+        scanner_map = {s.name: s for s in self._scanners}
+
+        for step in plan.steps:
+            scanner = scanner_map.get(step.scanner_name)
+            if not scanner:
+                report.errors.append(f"Scanner not found: {step.scanner_name}")
+                continue
+
+            try:
+                results = await scanner.execute(step.rules, step.config)
+                report.results.extend(results)
+            except Exception as e:
+                report.errors.append(
+                    f"Scanner {step.scanner_name} failed for {step.benchmark_id}: {e}"
+                )
+                # Mark rules as error
+                for rule in step.rules:
+                    report.results.append(
+                        TestResult(
+                            rule_id=rule.get("rule_id", "unknown"),
+                            benchmark_id=step.benchmark_id,
+                            status=TestStatus.ERROR,
+                            tool=step.scanner_name,
+                            tool_output=str(e)[:2000],
+                        )
+                    )
+
+        report.completed_at = datetime.now(timezone.utc)
+        return report
+
+    async def run(
+        self,
+        client,  # PretorianClient
+        system_id: str,
+        stig_id: str | None = None,
+        preferred_scanner: str | None = None,
+        scanner_config: dict | None = None,
+        dry_run: bool = False,
+    ) -> ScanReport:
+        """
+        Full scan pipeline: manifest → detect → plan → execute → upload.
+
+        Args:
+            client: Authenticated PretorianClient
+            system_id: System to scan
+            stig_id: Optional specific STIG to scan
+            preferred_scanner: Force use of a specific scanner
+            scanner_config: Per-scanner configuration
+            dry_run: If True, plan but don't execute or upload
+        """
+        from pretorin import __version__
+
+        # 1. Pull manifest
+        manifest = await client.get_test_manifest(system_id, stig_id=stig_id)
+
+        # 2. Detect scanners
+        await self.detect_scanners()
+
+        # 3. Plan
+        plan = self.plan_scan(
+            manifest,
+            scanner_config=scanner_config,
+            preferred_scanner=preferred_scanner,
+        )
+
+        if dry_run:
+            # Return empty report with plan info
+            report = ScanReport(
+                cli_run_id="dry-run",
+                started_at=datetime.now(timezone.utc),
+                completed_at=datetime.now(timezone.utc),
+            )
+            return report
+
+        # 4. Execute
+        report = await self.execute_plan(plan)
+
+        # 5. Upload results
+        if report.results:
+            result_dicts = [
+                {
+                    "rule_id": r.rule_id,
+                    "benchmark_id": r.benchmark_id,
+                    "status": r.status.value,
+                    "tested_at": r.tested_at.isoformat(),
+                    "tool": r.tool,
+                    "tool_version": r.tool_version,
+                    "tool_output": r.tool_output[:10000] if r.tool_output else None,
+                }
+                for r in report.results
+            ]
+
+            try:
+                submit_response = await client.submit_test_results(
+                    system_id,
+                    cli_run_id=report.cli_run_id,
+                    results=result_dicts,
+                    cli_version=__version__,
+                )
+                accepted = submit_response.get("accepted", 0)
+                rejected = submit_response.get("rejected", 0)
+                if rejected > 0:
+                    report.errors.extend(submit_response.get("errors", []))
+            except Exception as e:
+                report.errors.append(f"Failed to upload results: {e}")
+
+        return report

--- a/src/pretorin/scanners/orchestrator.py
+++ b/src/pretorin/scanners/orchestrator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Any
 
 from pretorin.scanners.base import ScannerBase, ScannerInfo, TestResult, TestStatus
 
@@ -23,8 +24,8 @@ class ScanPlanStep:
 
     scanner_name: str
     benchmark_id: str
-    rules: list[dict]
-    config: dict = field(default_factory=dict)
+    rules: list[dict[str, Any]]
+    config: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -32,7 +33,7 @@ class ScanPlan:
     """Full scan execution plan."""
 
     steps: list[ScanPlanStep]
-    unassigned_rules: list[dict] = field(default_factory=list)
+    unassigned_rules: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -104,8 +105,8 @@ class ScanOrchestrator:
 
     def plan_scan(
         self,
-        manifest: dict,
-        scanner_config: dict | None = None,
+        manifest: dict[str, Any],
+        scanner_config: dict[str, Any] | None = None,
         preferred_scanner: str | None = None,
     ) -> ScanPlan:
         """
@@ -116,7 +117,7 @@ class ScanOrchestrator:
         """
         scanner_config = scanner_config or {}
         steps: list[ScanPlanStep] = []
-        unassigned: list[dict] = []
+        unassigned: list[dict[str, Any]] = []
 
         # Build scanner lookup: name → (scanner, info)
         available = {
@@ -211,7 +212,7 @@ class ScanOrchestrator:
         system_id: str,
         stig_id: str | None = None,
         preferred_scanner: str | None = None,
-        scanner_config: dict | None = None,
+        scanner_config: dict[str, Any] | None = None,
         dry_run: bool = False,
     ) -> ScanReport:
         """
@@ -274,9 +275,7 @@ class ScanOrchestrator:
                     results=result_dicts,
                     cli_version=__version__,
                 )
-                accepted = submit_response.get("accepted", 0)
-                rejected = submit_response.get("rejected", 0)
-                if rejected > 0:
+                if submit_response.get("rejected", 0) > 0:
                     report.errors.extend(submit_response.get("errors", []))
             except Exception as e:
                 report.errors.append(f"Failed to upload results: {e}")


### PR DESCRIPTION
## Summary

New CLI commands and scanner module for DoD RMF traceability:

- **`pretorin stig`** — list/show/rules/applicable/infer commands for STIG browsing
- **`pretorin cci`** — list/show/chain commands with traceability tree view
- **`pretorin scan`** — doctor/manifest/run/results for compliance scanning
- **Scanner module** — OpenSCAP, InSpec, AWS Security Hub, Azure Policy, manual scanners
- **Scan orchestrator** — manifest → detect → plan → execute → upload pipeline
- **API client** — 12 new methods for CCI/STIG/test-results endpoints
- **Agent skills** — stig-scan, cci-assessment

Companion platform PR: pretorin-ai/monorepo#396

## Test plan

- [ ] `pretorin stig list` works against platform with DoD data synced
- [ ] `pretorin cci chain ac-2` shows traceability tree
- [ ] `pretorin scan doctor` detects available scanners
- [ ] `pretorin scan manifest` shows test manifest for active system
- [ ] All imports verified (`python -c "from pretorin.scanners import *"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)