### PR TITLE
feat: Add STIG/CCI MCP tools and agent tools (v0.13.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.12.0"
+version = "0.13.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/src/pretorin/agent/tools.py
+++ b/src/pretorin/agent/tools.py
@@ -713,4 +713,258 @@ def create_platform_tools(
         )
     )
 
+    # --- STIG / CCI ---
+
+    async def list_stigs(
+        technology_area: str | None = None,
+        product: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> str:
+        result = await client.list_stigs(
+            technology_area=technology_area,
+            product=product,
+            limit=limit,
+            offset=offset,
+        )
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="list_stigs",
+            description="List STIG benchmarks with optional filters by technology area or product",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "technology_area": {"type": "string", "description": "Filter by technology area"},
+                    "product": {"type": "string", "description": "Filter by product name"},
+                    "limit": {"type": "integer", "description": "Max results", "default": 100},
+                    "offset": {"type": "integer", "description": "Pagination offset", "default": 0},
+                },
+                "required": [],
+            },
+            handler=list_stigs,
+        )
+    )
+
+    async def list_stig_rules(
+        stig_id: str,
+        severity: str | None = None,
+        cci_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> str:
+        result = await client.list_stig_rules(
+            stig_id=stig_id,
+            severity=severity,
+            cci_id=cci_id,
+            limit=limit,
+            offset=offset,
+        )
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="list_stig_rules",
+            description="List rules for a STIG benchmark with optional severity and CCI filters",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "stig_id": {"type": "string", "description": "STIG benchmark ID"},
+                    "severity": {"type": "string", "description": "Filter by severity (high, medium, low)"},
+                    "cci_id": {"type": "string", "description": "Filter by CCI identifier"},
+                    "limit": {"type": "integer", "description": "Max results", "default": 100},
+                    "offset": {"type": "integer", "description": "Pagination offset", "default": 0},
+                },
+                "required": ["stig_id"],
+            },
+            handler=list_stig_rules,
+        )
+    )
+
+    async def get_stig_rule(stig_id: str, rule_id: str) -> str:
+        result = await client.get_stig_rule(stig_id=stig_id, rule_id=rule_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="get_stig_rule",
+            description="Get full detail for a single STIG rule including CCIs, check text, and fix text",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "stig_id": {"type": "string", "description": "STIG benchmark ID"},
+                    "rule_id": {"type": "string", "description": "STIG rule ID"},
+                },
+                "required": ["stig_id", "rule_id"],
+            },
+            handler=get_stig_rule,
+        )
+    )
+
+    async def list_ccis(
+        nist_control_id: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> str:
+        result = await client.list_ccis(
+            nist_control_id=nist_control_id,
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="list_ccis",
+            description="List CCI items with optional filters by NIST control ID or status",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "nist_control_id": {"type": "string", "description": "Filter by NIST control ID (e.g., AC-2)"},
+                    "status": {"type": "string", "description": "Filter by CCI status"},
+                    "limit": {"type": "integer", "description": "Max results", "default": 100},
+                    "offset": {"type": "integer", "description": "Pagination offset", "default": 0},
+                },
+                "required": [],
+            },
+            handler=list_ccis,
+        )
+    )
+
+    async def get_cci(cci_id: str) -> str:
+        result = await client.get_cci(cci_id=cci_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="get_cci",
+            description="Get CCI detail with linked SRGs and STIG rules",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "cci_id": {"type": "string", "description": "CCI identifier (e.g., CCI-000015)"},
+                },
+                "required": ["cci_id"],
+            },
+            handler=get_cci,
+        )
+    )
+
+    async def get_test_manifest(system_id: str, stig_id: str | None = None) -> str:
+        result = await client.get_test_manifest(system_id=system_id, stig_id=stig_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="get_test_manifest",
+            description="Get the test manifest for CLI scan execution against a system",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "system_id": {"type": "string", "description": "System ID"},
+                    "stig_id": {"type": "string", "description": "Optional STIG benchmark ID to scope the manifest"},
+                },
+                "required": ["system_id"],
+            },
+            handler=get_test_manifest,
+        )
+    )
+
+    async def submit_test_results(
+        system_id: str,
+        cli_run_id: str,
+        results: list[dict[str, Any]],
+        cli_version: str | None = None,
+    ) -> str:
+        result = await client.submit_test_results(
+            system_id=system_id,
+            cli_run_id=cli_run_id,
+            results=results,
+            cli_version=cli_version,
+        )
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="submit_test_results",
+            description="Upload STIG scan results from a CLI scan run",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "system_id": {"type": "string", "description": "System ID"},
+                    "cli_run_id": {"type": "string", "description": "CLI scan run identifier"},
+                    "results": {
+                        "type": "array",
+                        "description": "Array of test result objects",
+                        "items": {"type": "object"},
+                    },
+                    "cli_version": {"type": "string", "description": "Optional CLI version string"},
+                },
+                "required": ["system_id", "cli_run_id", "results"],
+            },
+            handler=submit_test_results,
+        )
+    )
+
+    async def get_stig_applicability(system_id: str) -> str:
+        result = await client.get_stig_applicability(system_id=system_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="get_stig_applicability",
+            description="Get which STIGs apply to a system based on its profile",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "system_id": {"type": "string", "description": "System ID"},
+                },
+                "required": ["system_id"],
+            },
+            handler=get_stig_applicability,
+        )
+    )
+
+    async def get_cci_status(system_id: str, nist_control_id: str | None = None) -> str:
+        result = await client.get_cci_status(system_id=system_id, nist_control_id=nist_control_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="get_cci_status",
+            description="Get CCI-level compliance rollup for a system",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "system_id": {"type": "string", "description": "System ID"},
+                    "nist_control_id": {"type": "string", "description": "Optional NIST control ID filter"},
+                },
+                "required": ["system_id"],
+            },
+            handler=get_cci_status,
+        )
+    )
+
+    async def infer_stigs(system_id: str) -> str:
+        result = await client.infer_stigs(system_id=system_id)
+        return json.dumps(result, default=str)
+
+    tools.append(
+        ToolDefinition(
+            name="infer_stigs",
+            description="AI-infer applicable STIGs from a system's profile",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "system_id": {"type": "string", "description": "System ID"},
+                },
+                "required": ["system_id"],
+            },
+            handler=infer_stigs,
+        )
+    )
+
     return tools

--- a/src/pretorin/mcp/handlers/__init__.py
+++ b/src/pretorin/mcp/handlers/__init__.py
@@ -40,6 +40,18 @@ from pretorin.mcp.handlers.frameworks import (
     handle_list_controls,
     handle_list_frameworks,
 )
+from pretorin.mcp.handlers.stig import (
+    handle_get_cci,
+    handle_get_cci_status,
+    handle_get_stig_applicability,
+    handle_get_stig_rule,
+    handle_get_test_manifest,
+    handle_infer_stigs,
+    handle_list_ccis,
+    handle_list_stig_rules,
+    handle_list_stigs,
+    handle_submit_test_results,
+)
 from pretorin.mcp.handlers.systems import (
     handle_get_compliance_status,
     handle_get_system,
@@ -166,4 +178,15 @@ TOOL_HANDLERS: dict[str, ToolHandler] = {
     "pretorin_get_stale_edges": handle_get_stale_edges,
     "pretorin_sync_stale_edges": handle_sync_stale_edges,
     "pretorin_generate_inheritance_narrative": handle_generate_inheritance_narrative,
+    # STIG / CCI Tools
+    "pretorin_list_stigs": handle_list_stigs,
+    "pretorin_list_stig_rules": handle_list_stig_rules,
+    "pretorin_get_stig_rule": handle_get_stig_rule,
+    "pretorin_list_ccis": handle_list_ccis,
+    "pretorin_get_cci": handle_get_cci,
+    "pretorin_get_test_manifest": handle_get_test_manifest,
+    "pretorin_submit_test_results": handle_submit_test_results,
+    "pretorin_get_stig_applicability": handle_get_stig_applicability,
+    "pretorin_get_cci_status": handle_get_cci_status,
+    "pretorin_infer_stigs": handle_infer_stigs,
 }

--- a/src/pretorin/mcp/handlers/stig.py
+++ b/src/pretorin/mcp/handlers/stig.py
@@ -1,0 +1,199 @@
+"""Handlers for STIG and CCI tools."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent
+
+from pretorin.client import PretorianClient
+from pretorin.mcp.helpers import (
+    format_error,
+    format_json,
+    require,
+    resolve_system_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_args(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return arguments with sensitive fields redacted."""
+    return {k: ("***" if k == "api_key" else v) for k, v in arguments.items()}
+
+
+# ---------------------------------------------------------------------------
+# Read-only reference tools (no system_id required)
+# ---------------------------------------------------------------------------
+
+
+async def handle_list_stigs(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    """Handle the list_stigs tool."""
+    logger.debug("handle_list_stigs called with %s", _safe_args(arguments))
+    result = await client.list_stigs(
+        technology_area=arguments.get("technology_area"),
+        product=arguments.get("product"),
+        limit=arguments.get("limit", 100),
+        offset=arguments.get("offset", 0),
+    )
+    return format_json(result)
+
+
+async def handle_list_stig_rules(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the list_stig_rules tool."""
+    logger.debug("handle_list_stig_rules called with %s", _safe_args(arguments))
+    err = require(arguments, "stig_id")
+    if err:
+        return format_error(err)
+
+    result = await client.list_stig_rules(
+        stig_id=arguments["stig_id"],
+        severity=arguments.get("severity"),
+        cci_id=arguments.get("cci_id"),
+        limit=arguments.get("limit", 100),
+        offset=arguments.get("offset", 0),
+    )
+    return format_json(result)
+
+
+async def handle_get_stig_rule(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the get_stig_rule tool."""
+    logger.debug("handle_get_stig_rule called with %s", _safe_args(arguments))
+    err = require(arguments, "stig_id", "rule_id")
+    if err:
+        return format_error(err)
+
+    result = await client.get_stig_rule(
+        stig_id=arguments["stig_id"],
+        rule_id=arguments["rule_id"],
+    )
+    return format_json(result)
+
+
+async def handle_list_ccis(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    """Handle the list_ccis tool."""
+    logger.debug("handle_list_ccis called with %s", _safe_args(arguments))
+    result = await client.list_ccis(
+        nist_control_id=arguments.get("nist_control_id"),
+        status=arguments.get("status"),
+        limit=arguments.get("limit", 100),
+        offset=arguments.get("offset", 0),
+    )
+    return format_json(result)
+
+
+async def handle_get_cci(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the get_cci tool."""
+    logger.debug("handle_get_cci called with %s", _safe_args(arguments))
+    err = require(arguments, "cci_id")
+    if err:
+        return format_error(err)
+
+    result = await client.get_cci(cci_id=arguments["cci_id"])
+    return format_json(result)
+
+
+# ---------------------------------------------------------------------------
+# System-scoped tools (require system_id)
+# ---------------------------------------------------------------------------
+
+
+async def handle_get_test_manifest(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the get_test_manifest tool."""
+    logger.debug("handle_get_test_manifest called with %s", _safe_args(arguments))
+    system_id = await resolve_system_id(client, arguments)
+    if system_id is None:
+        return format_error("system_id is required")
+
+    result = await client.get_test_manifest(
+        system_id=system_id,
+        stig_id=arguments.get("stig_id"),
+    )
+    return format_json(result)
+
+
+async def handle_submit_test_results(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the submit_test_results tool."""
+    logger.debug("handle_submit_test_results called with %s", _safe_args(arguments))
+    err = require(arguments, "cli_run_id", "results")
+    if err:
+        return format_error(err)
+
+    system_id = await resolve_system_id(client, arguments)
+    if system_id is None:
+        return format_error("system_id is required")
+
+    result = await client.submit_test_results(
+        system_id=system_id,
+        cli_run_id=arguments["cli_run_id"],
+        results=arguments["results"],
+        cli_version=arguments.get("cli_version"),
+    )
+    return format_json(result)
+
+
+async def handle_get_stig_applicability(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the get_stig_applicability tool."""
+    logger.debug("handle_get_stig_applicability called with %s", _safe_args(arguments))
+    system_id = await resolve_system_id(client, arguments)
+    if system_id is None:
+        return format_error("system_id is required")
+
+    result = await client.get_stig_applicability(system_id=system_id)
+    return format_json(result)
+
+
+async def handle_get_cci_status(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the get_cci_status tool."""
+    logger.debug("handle_get_cci_status called with %s", _safe_args(arguments))
+    system_id = await resolve_system_id(client, arguments)
+    if system_id is None:
+        return format_error("system_id is required")
+
+    result = await client.get_cci_status(
+        system_id=system_id,
+        nist_control_id=arguments.get("nist_control_id"),
+    )
+    return format_json(result)
+
+
+async def handle_infer_stigs(
+    client: PretorianClient,
+    arguments: dict[str, Any],
+) -> list[TextContent] | CallToolResult:
+    """Handle the infer_stigs tool."""
+    logger.debug("handle_infer_stigs called with %s", _safe_args(arguments))
+    system_id = await resolve_system_id(client, arguments)
+    if system_id is None:
+        return format_error("system_id is required")
+
+    result = await client.infer_stigs(system_id=system_id)
+    return format_json(result)

--- a/src/pretorin/mcp/tools.py
+++ b/src/pretorin/mcp/tools.py
@@ -1333,4 +1333,203 @@ async def list_tools() -> list[Tool]:
                 "required": ["system_id", "control_id", "framework_id"],
             },
         ),
+        # === STIG / CCI Tools ===
+        Tool(
+            name="pretorin_list_stigs",
+            description="List STIG benchmarks with optional filters by technology area or product.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "technology_area": {
+                        "type": "string",
+                        "description": "Filter by technology area",
+                    },
+                    "product": {
+                        "type": "string",
+                        "description": "Filter by product name",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return",
+                        "default": 100,
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Offset for pagination",
+                        "default": 0,
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="pretorin_list_stig_rules",
+            description="List rules for a STIG benchmark with optional severity and CCI filters.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "stig_id": {
+                        "type": "string",
+                        "description": "The STIG benchmark ID",
+                    },
+                    "severity": {
+                        "type": "string",
+                        "description": "Filter by severity (high, medium, low)",
+                    },
+                    "cci_id": {
+                        "type": "string",
+                        "description": "Filter by CCI identifier",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return",
+                        "default": 100,
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Offset for pagination",
+                        "default": 0,
+                    },
+                },
+                "required": ["stig_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_get_stig_rule",
+            description="Get full detail for a single STIG rule including CCIs, check text, and fix text.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "stig_id": {
+                        "type": "string",
+                        "description": "The STIG benchmark ID",
+                    },
+                    "rule_id": {
+                        "type": "string",
+                        "description": "The STIG rule ID",
+                    },
+                },
+                "required": ["stig_id", "rule_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_list_ccis",
+            description="List CCI items with optional filters by NIST control ID or status.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "nist_control_id": {
+                        "type": "string",
+                        "description": "Filter by NIST control ID (e.g., AC-2)",
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Filter by CCI status",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return",
+                        "default": 100,
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Offset for pagination",
+                        "default": 0,
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="pretorin_get_cci",
+            description="Get CCI detail with linked SRGs and STIG rules.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "cci_id": {
+                        "type": "string",
+                        "description": "The CCI identifier (e.g., CCI-000015)",
+                    },
+                },
+                "required": ["cci_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_get_test_manifest",
+            description="Get the test manifest for CLI scan execution against a system.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": system_id_property(),
+                    "stig_id": {
+                        "type": "string",
+                        "description": "Optional STIG benchmark ID to scope the manifest",
+                    },
+                },
+                "required": ["system_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_submit_test_results",
+            description="Upload STIG scan results from a CLI scan run.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": system_id_property(),
+                    "cli_run_id": {
+                        "type": "string",
+                        "description": "The CLI scan run identifier",
+                    },
+                    "results": {
+                        "type": "array",
+                        "description": "Array of test result objects",
+                        "items": {
+                            "type": "object",
+                        },
+                    },
+                    "cli_version": {
+                        "type": "string",
+                        "description": "Optional CLI version string",
+                    },
+                },
+                "required": ["system_id", "cli_run_id", "results"],
+            },
+        ),
+        Tool(
+            name="pretorin_get_stig_applicability",
+            description="Get which STIGs apply to a system based on its profile.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": system_id_property(),
+                },
+                "required": ["system_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_get_cci_status",
+            description="Get CCI-level compliance rollup for a system, optionally filtered by NIST control.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": system_id_property(),
+                    "nist_control_id": {
+                        "type": "string",
+                        "description": "Optional NIST control ID to filter (e.g., AC-2)",
+                    },
+                },
+                "required": ["system_id"],
+            },
+        ),
+        Tool(
+            name="pretorin_infer_stigs",
+            description="AI-infer applicable STIGs from a system's profile.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "system_id": system_id_property(),
+                },
+                "required": ["system_id"],
+            },
+        ),
     ]

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -67,9 +67,20 @@ class TestToolListing:
             "pretorin_submit_campaign_proposal",
             "pretorin_apply_campaign",
             "pretorin_get_campaign_status",
+            # STIG / CCI 10
+            "pretorin_list_stigs",
+            "pretorin_list_stig_rules",
+            "pretorin_get_stig_rule",
+            "pretorin_list_ccis",
+            "pretorin_get_cci",
+            "pretorin_get_test_manifest",
+            "pretorin_submit_test_results",
+            "pretorin_get_stig_applicability",
+            "pretorin_get_cci_status",
+            "pretorin_infer_stigs",
         ]
 
-        assert len(tools) == 70
+        assert len(tools) == 80
         for name in expected:
             assert name in tool_names, f"Missing tool: {name}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "pretorin"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Add 10 STIG/CCI tools to the MCP server (`pretorin mcp-serve`) and agent tool system
- Create `src/pretorin/mcp/handlers/stig.py` with handlers for all 10 tools
- Register tool schemas, dispatch entries, and agent `ToolDefinition` entries
- Enables the `stig-scan` and `cci-assessment` skills to function
- Bump version to 0.13.0

Closes #53

**Note:** `get_stig` and `get_cci_chain` tools were skipped — platform endpoints don't exist yet (tracked in #54, monorepo#402, monorepo#403).

## Test plan

- [x] `ruff check` passes on all modified files
- [x] All 10 MCP tools appear in `list_tools()` output (80 total)
- [x] All 10 dispatch entries wired in `TOOL_HANDLERS`
- [x] Skill `tool_names` for `stig-scan` and `cci-assessment` align with agent tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)