### PR TITLE
docs: update documentation for v0.10–v0.13 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,57 @@ Platform-backed review and update workflows are single-scope: set one active `sy
 | `pretorin skill status` | Check skill install status per agent |
 | `pretorin mcp-serve` | Start MCP server |
 
+### Campaign Workflows
+
+Campaigns let you run bulk compliance operations across multiple controls, policies, or scope questions in a single coordinated run. Campaigns support an external-agent-first pattern with checkpoint persistence and lease-based concurrency.
+
+| Command | Purpose |
+|---------|---------|
+| `pretorin campaign controls --mode initial --family AC` | Draft narratives/evidence for a control family |
+| `pretorin campaign controls --mode notes-fix --family AC` | Fix controls flagged by platform notes |
+| `pretorin campaign controls --mode review-fix --family AC` | Fix controls flagged by family review |
+| `pretorin campaign policy --mode answer --all-incomplete` | Answer all incomplete policy questions |
+| `pretorin campaign scope --mode answer` | Answer scope questions for a system/framework |
+| `pretorin campaign status --checkpoint <path>` | Check campaign progress |
+
+### Vendor Management & Inheritance
+
+Manage vendor entities (CSPs, SaaS, managed services) and track control inheritance through vendor responsibility edges.
+
+| Command | Purpose |
+|---------|---------|
+| `pretorin vendor list` | List all vendors |
+| `pretorin vendor create <name> --type csp` | Create a vendor entity |
+| `pretorin vendor get <id>` | Get vendor details |
+| `pretorin vendor upload-doc <id> <file>` | Upload vendor evidence document |
+| `pretorin vendor list-docs <id>` | List vendor documents |
+
+### STIG & CCI Browsing
+
+Browse STIG benchmarks, rules, and CCIs with full traceability from NIST 800-53 controls down to individual STIG check rules.
+
+| Command | Purpose |
+|---------|---------|
+| `pretorin stig list` | List STIG benchmarks |
+| `pretorin stig show <id>` | Show STIG benchmark detail |
+| `pretorin stig rules <id>` | List rules for a benchmark |
+| `pretorin stig applicable` | Show applicable STIGs for active system |
+| `pretorin stig infer` | AI-infer applicable STIGs from system profile |
+| `pretorin cci list` | List CCIs with optional control filter |
+| `pretorin cci show <id>` | Show CCI detail with linked SRGs and rules |
+| `pretorin cci chain <control_id>` | Full traceability: Control -> CCIs -> STIG rules |
+
+### STIG Scanning
+
+Run STIG compliance scans using available scanner tools (OpenSCAP, InSpec, AWS/Azure Cloud Scanners).
+
+| Command | Purpose |
+|---------|---------|
+| `pretorin scan doctor` | Check installed scanner tools |
+| `pretorin scan manifest` | Show test manifest for active system |
+| `pretorin scan run` | Execute STIG compliance scans |
+| `pretorin scan results` | View CCI-level test results |
+
 Quick context checks:
 
 ```bash

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -668,6 +668,97 @@ Different frameworks use different ID conventions. Always use `pretorin framewor
 | `nist-800-171-r3` | NIST SP 800-171 Revision 3 | 17 | 130 |
 | `nist-800-53-r5` | NIST SP 800-53 Rev 5 | 20 | 324 |
 
+## Campaign Commands
+
+The `campaign` command group runs bulk compliance operations across multiple controls, policies, or scope questions.
+
+### Control Campaigns
+
+```bash
+# Draft new narratives for the Access Control family
+pretorin campaign controls --mode initial --family AC \
+  --system "My System" --framework-id fedramp-moderate
+
+# Fix controls flagged by platform notes
+pretorin campaign controls --mode notes-fix --family AC
+
+# Fix controls flagged by family review
+pretorin campaign controls --mode review-fix --family AC --review-job <job-id>
+```
+
+### Policy Campaigns
+
+```bash
+pretorin campaign policy --mode answer --all-incomplete
+```
+
+### Scope Campaigns
+
+```bash
+pretorin campaign scope --mode answer \
+  --system "My System" --framework-id fedramp-moderate
+```
+
+### Campaign Status
+
+```bash
+pretorin campaign status --checkpoint .pretorin/campaign-checkpoint.json
+```
+
+Campaign modes: `initial` (new drafts), `notes-fix` (fix platform notes), `review-fix` (fix review findings), `answer` (policy/scope questions).
+
+## Vendor Commands
+
+The `vendor` command group manages vendor entities and their evidence documents.
+
+```bash
+pretorin vendor list
+pretorin vendor create "AWS" --type csp --description "Cloud provider"
+pretorin vendor get <vendor_id>
+pretorin vendor update <vendor_id> --name "AWS GovCloud"
+pretorin vendor delete <vendor_id> --force
+pretorin vendor upload-doc <vendor_id> ./soc2-report.pdf --name "SOC 2" --attestation-type third_party_attestation
+pretorin vendor list-docs <vendor_id>
+```
+
+Vendor types: `csp`, `saas`, `managed_service`, `internal`
+
+## STIG Commands
+
+Browse STIG benchmarks and rules.
+
+```bash
+pretorin stig list --technology-area "Network"
+pretorin stig show <stig_id>
+pretorin stig rules <stig_id> --severity high
+pretorin stig applicable --system "My System"
+pretorin stig infer --system "My System"
+```
+
+## CCI Commands
+
+Browse CCIs and the full traceability chain from NIST 800-53 controls to STIG rules.
+
+```bash
+pretorin cci list --control ac-2
+pretorin cci show CCI-000015
+pretorin cci chain ac-2 --system "My System"
+```
+
+## Scan Commands
+
+Run STIG compliance scans using available scanner tools.
+
+```bash
+pretorin scan doctor                          # check installed scanners
+pretorin scan manifest --system "My System"   # view test manifest
+pretorin scan run --system "My System"        # execute scans
+pretorin scan run --dry-run                   # preview without executing
+pretorin scan results --control ac-2          # view CCI-level results
+```
+
+Supported scanners: OpenSCAP, InSpec, AWS Cloud Scanner, Azure Cloud Scanner, Manual.
+
 ## Complete Command Reference
 
 | Command | Description |
@@ -701,6 +792,29 @@ Different frameworks use different ID conventions. Always use `pretorin framewor
 | `pretorin notes list <ctrl> <fw>` | List control notes |
 | `pretorin notes add <ctrl> <fw> --content ...` | Add a control note |
 | `pretorin monitoring push` | Push a monitoring event to a system |
+| `pretorin campaign controls` | Run bulk control campaign (`--mode`, `--family`, `--apply`) |
+| `pretorin campaign policy` | Run bulk policy campaign (`--mode`, `--all-incomplete`) |
+| `pretorin campaign scope` | Run bulk scope campaign (`--mode`) |
+| `pretorin campaign status` | Check campaign progress (`--checkpoint`) |
+| `pretorin vendor list` | List all vendors |
+| `pretorin vendor create <name>` | Create a vendor (`--type`, `--description`) |
+| `pretorin vendor get <id>` | Get vendor details |
+| `pretorin vendor update <id>` | Update vendor fields |
+| `pretorin vendor delete <id>` | Delete a vendor (`--force`) |
+| `pretorin vendor upload-doc <id> <file>` | Upload vendor evidence document |
+| `pretorin vendor list-docs <id>` | List vendor documents |
+| `pretorin stig list` | List STIG benchmarks (`--technology-area`, `--product`) |
+| `pretorin stig show <id>` | Show STIG benchmark detail |
+| `pretorin stig rules <id>` | List STIG rules (`--severity`, `--cci`) |
+| `pretorin stig applicable` | Show applicable STIGs for active system |
+| `pretorin stig infer` | AI-infer applicable STIGs |
+| `pretorin cci list` | List CCIs (`--control`, `--status`) |
+| `pretorin cci show <id>` | Show CCI detail |
+| `pretorin cci chain <ctrl>` | Full traceability chain (`--system`) |
+| `pretorin scan doctor` | Check installed scanner tools |
+| `pretorin scan manifest` | Show test manifest (`--system`, `--stig`) |
+| `pretorin scan run` | Run STIG scans (`--tool`, `--dry-run`) |
+| `pretorin scan results` | View CCI-level results (`--control`) |
 | `pretorin agent run "<task>"` | Run a compliance task with the Codex agent |
 | `pretorin agent run --skill <name>` | Run a predefined agent skill |
 | `pretorin agent doctor` | Validate Codex runtime setup |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -158,8 +158,9 @@ Restart the application to load the new MCP server.
 
 ## Available Tools
 
-The MCP server provides 29 tools for accessing and managing compliance data.
-The current tool surface is:
+The MCP server provides 80+ tools organized by category.
+
+### Framework & Control Reference
 
 | Tool | Description |
 |------|-------------|
@@ -171,27 +172,140 @@ The current tool surface is:
 | `pretorin_get_controls_batch` | Get detailed control data for many controls in one request |
 | `pretorin_get_control_references` | Get control guidance, objectives, and related controls |
 | `pretorin_get_document_requirements` | Get document requirements for a framework |
+
+### Systems
+
+| Tool | Description |
+|------|-------------|
 | `pretorin_list_systems` | List systems in the current organization |
 | `pretorin_get_system` | Get system metadata, attached frameworks, and impact level |
 | `pretorin_get_compliance_status` | Get implementation progress for a system |
+
+### Evidence Management
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_search_evidence` | Search current evidence items |
+| `pretorin_create_evidence` | Upsert evidence (find-or-create by default) |
+| `pretorin_create_evidence_batch` | Create and link multiple evidence items in one scoped request |
+| `pretorin_link_evidence` | Link an existing evidence item to a control |
+
+### Implementation Context
+
+| Tool | Description |
+|------|-------------|
 | `pretorin_get_control_context` | Get rich control context: AI guidance, statement, objectives, and implementation details |
 | `pretorin_get_scope` | Get scope narrative, exclusions, and scope Q&A |
 | `pretorin_get_narrative` | Get the current narrative for a control |
 | `pretorin_get_control_implementation` | Get implementation status, narrative, evidence count, and notes |
 | `pretorin_get_control_notes` | Read notes for a control implementation |
-| `pretorin_search_evidence` | Search current evidence items |
-| `pretorin_create_evidence` | Upsert evidence (find-or-create by default) |
-| `pretorin_create_evidence_batch` | Create and link multiple evidence items in one scoped request |
-| `pretorin_link_evidence` | Link an existing evidence item to a control |
-| `pretorin_patch_scope_qa` | Update scope questionnaire answers for a system/framework |
-| `pretorin_list_org_policies` | List organization policies available for questionnaire work |
-| `pretorin_get_org_policy_questionnaire` | Get canonical questionnaire state for one organization policy |
-| `pretorin_patch_org_policy_qa` | Update organization policy questionnaire answers |
 | `pretorin_update_narrative` | Push a narrative text update for a control implementation |
 | `pretorin_add_control_note` | Add a control note with manual follow-up guidance |
 | `pretorin_update_control_status` | Update a control implementation status |
-| `pretorin_push_monitoring_event` | Create a monitoring event for a system |
 | `pretorin_generate_control_artifacts` | Generate read-only AI narrative and evidence-gap drafts |
+
+### Monitoring
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_push_monitoring_event` | Create a monitoring event for a system |
+
+### Workflow State & Analytics
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_get_workflow_state` | Get lifecycle state for a system+framework (scope, policies, controls, evidence) |
+| `pretorin_get_analytics_summary` | Lightweight system progress snapshot |
+| `pretorin_get_family_analytics` | Per-family breakdown: narrative coverage, evidence, status distribution |
+| `pretorin_get_policy_analytics` | Per-policy breakdown: answer completion, review status |
+
+### Family Operations
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_get_pending_families` | Identify families that need work (pending vs total counts) |
+| `pretorin_get_family_bundle` | Get all controls in a family with status, narrative, evidence, notes |
+| `pretorin_trigger_family_review` | Trigger AI review of all controls in a family |
+| `pretorin_get_family_review_results` | Poll family review results with findings |
+
+### Scope Workflow
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_get_pending_scope_questions` | Get only unanswered scope questions |
+| `pretorin_get_scope_question_detail` | Get guidance, tips, and examples for a scope question |
+| `pretorin_answer_scope_question` | Answer one scope question |
+| `pretorin_patch_scope_qa` | Batch update scope questionnaire answers |
+| `pretorin_trigger_scope_generation` | Trigger AI scope document generation |
+| `pretorin_trigger_scope_review` | Trigger AI scope review |
+| `pretorin_get_scope_review_results` | Poll scope review results |
+
+### Policy Workflow
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_list_org_policies` | List organization policies |
+| `pretorin_get_org_policy_questionnaire` | Get policy questionnaire state |
+| `pretorin_get_pending_policy_questions` | Get only unanswered policy questions |
+| `pretorin_get_policy_question_detail` | Get guidance for a policy question |
+| `pretorin_answer_policy_question` | Answer one policy question |
+| `pretorin_patch_org_policy_qa` | Batch update policy questionnaire answers |
+| `pretorin_get_policy_workflow_state` | Per-policy completion and review status |
+| `pretorin_trigger_policy_generation` | Trigger AI policy document generation |
+| `pretorin_trigger_policy_review` | Trigger AI policy review |
+| `pretorin_get_policy_review_results` | Poll policy review results |
+
+### Campaign Operations
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_prepare_campaign` | Prepare a campaign run with platform state snapshot |
+| `pretorin_claim_campaign_items` | Claim items for drafting with TTL-based leases |
+| `pretorin_get_campaign_item_context` | Get full item context and drafting instructions |
+| `pretorin_submit_campaign_proposal` | Submit a proposal without applying to platform |
+| `pretorin_apply_campaign` | Push accepted proposals to the platform |
+| `pretorin_get_campaign_status` | Get structured campaign status snapshot |
+
+### Vendor Management
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_list_vendors` | List all vendor entities |
+| `pretorin_create_vendor` | Create a vendor (CSP, SaaS, managed service, internal) |
+| `pretorin_get_vendor` | Get vendor details |
+| `pretorin_update_vendor` | Update vendor fields |
+| `pretorin_delete_vendor` | Delete a vendor entity |
+| `pretorin_upload_vendor_document` | Upload vendor evidence documents |
+| `pretorin_list_vendor_documents` | List documents linked to a vendor |
+| `pretorin_link_evidence_to_vendor` | Link evidence to a vendor with attestation type |
+
+### Inheritance & Responsibility
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_set_control_responsibility` | Mark control as inherited/shared from a provider |
+| `pretorin_get_control_responsibility` | Check if control is inherited and from where |
+| `pretorin_remove_control_responsibility` | Convert inherited control to system-specific |
+| `pretorin_generate_inheritance_narrative` | AI-generate inheritance narrative from vendor docs |
+| `pretorin_get_stale_edges` | Identify controls with stale inheritance |
+| `pretorin_sync_stale_edges` | Bulk update inherited controls from source narratives |
+
+### STIG & CCI
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_list_stigs` | List STIG benchmarks with filters |
+| `pretorin_get_stig` | Get STIG benchmark detail |
+| `pretorin_list_stig_rules` | List rules with severity/CCI filters |
+| `pretorin_get_stig_rule` | Full rule detail: check text, fix text, CCIs |
+| `pretorin_list_ccis` | List CCIs with optional control filter |
+| `pretorin_get_cci` | CCI detail with linked SRGs and rules |
+| `pretorin_get_cci_chain` | Full traceability: Control -> CCIs -> SRGs -> STIG rules |
+| `pretorin_get_cci_status` | CCI-level compliance rollup for a system |
+| `pretorin_get_stig_applicability` | Which STIGs apply to a system |
+| `pretorin_infer_stigs` | AI-infer applicable STIGs from system profile |
+| `pretorin_get_test_manifest` | Fetch test manifest for a system |
+| `pretorin_submit_test_results` | Upload STIG scan results |
 
 `pretorin_generate_control_artifacts` is read-only. Use `pretorin_update_narrative`, `pretorin_create_evidence`, and `pretorin_add_control_note` to persist approved changes.
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,10 @@
 - [Narratives](./cli/narratives.md)
 - [Notes](./cli/notes.md)
 - [Monitoring](./cli/monitoring.md)
+- [Campaign Workflows](./cli/campaigns.md)
+- [Vendor Management](./cli/vendors.md)
+- [STIG & CCI Browsing](./cli/stig-cci.md)
+- [STIG Scanning](./cli/scanning.md)
 - [Review](./cli/review.md)
 - [Configuration](./cli/configuration.md)
 - [Complete Command Reference](./cli/command-reference.md)
@@ -43,10 +47,14 @@
 # Workflows
 
 - [Narrative & Evidence Workflow](./workflows/narrative-evidence.md)
+- [Campaign Workflows](./workflows/campaigns.md)
+- [Policy & Scope Questionnaires](./workflows/policy-scope.md)
+- [Vendor Inheritance](./workflows/vendor-inheritance.md)
 - [Gap Analysis](./workflows/gap-analysis.md)
     - [Example Report](./workflows/gap-analysis-example.md)
 - [Artifact Generation](./workflows/artifacts.md)
 - [Cross-Framework Mapping](./workflows/cross-framework.md)
+- [STIG Compliance Scanning](./workflows/stig-scanning.md)
 
 # Reference
 

--- a/docs/src/cli/campaigns.md
+++ b/docs/src/cli/campaigns.md
@@ -1,0 +1,93 @@
+# Campaign Workflows
+
+The `campaign` command group runs bulk compliance operations across multiple controls, policies, or scope questions in a single coordinated run. Campaigns support an external-agent-first pattern with checkpoint persistence and lease-based concurrency for safe fan-out to multiple agents.
+
+## Campaign Domains and Modes
+
+| Domain | Mode | Description |
+|--------|------|-------------|
+| `controls` | `initial` | Draft new narratives and evidence for controls |
+| `controls` | `notes-fix` | Address platform notes on existing controls |
+| `controls` | `review-fix` | Fix findings from a family review job |
+| `policy` | `answer` | Generate answers for policy questions |
+| `policy` | `review-fix` | Fix findings from a policy review |
+| `scope` | `answer` | Generate answers for scope questions |
+| `scope` | `review-fix` | Fix findings from a scope review |
+
+## Control Campaigns
+
+### Draft New Narratives for a Family
+
+```bash
+pretorin campaign controls --mode initial --family AC \
+  --system "My System" --framework-id fedramp-moderate
+```
+
+### Fix Controls with Platform Notes
+
+```bash
+pretorin campaign controls --mode notes-fix --family AC
+```
+
+### Fix Controls after Family Review
+
+```bash
+pretorin campaign controls --mode review-fix --family AC --review-job <job-id>
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--system` | Target system ID or name |
+| `--framework-id` | Target framework ID |
+| `--family` | Control family to target (e.g., `AC`, `AU`) |
+| `--controls` | Specific control IDs (comma-separated) |
+| `--all-controls` | Target all controls in the framework |
+| `--mode` | Campaign mode: `initial`, `notes-fix`, `review-fix` |
+| `--artifacts` | Generate AI artifacts during the campaign |
+| `--review-job` | Review job ID (required for `review-fix` mode) |
+| `--concurrency` | Number of parallel workers |
+| `--max-retries` | Maximum retry attempts per item |
+| `--checkpoint` | Path to checkpoint file for resume |
+| `--apply` | Apply proposals to platform after completion |
+| `--output` | Output mode: `auto`, `live`, `compact`, `json` |
+
+## Policy Campaigns
+
+### Answer All Incomplete Policy Questions
+
+```bash
+pretorin campaign policy --mode answer --all-incomplete
+```
+
+### Fix Policy Review Findings
+
+```bash
+pretorin campaign policy --mode review-fix --policies <policy-id>
+```
+
+## Scope Campaigns
+
+### Answer Scope Questions
+
+```bash
+pretorin campaign scope --mode answer \
+  --system "My System" --framework-id fedramp-moderate
+```
+
+## Checking Campaign Status
+
+```bash
+pretorin campaign status --checkpoint .pretorin/campaign-checkpoint.json
+```
+
+## Campaign Lifecycle
+
+1. **Prepare** — The campaign snapshots platform state and creates a local checkpoint file
+2. **Claim** — Items are claimed with TTL-based leases (safe for multiple agents)
+3. **Draft** — Each item gets full context and drafting instructions
+4. **Propose** — Proposals are submitted without writing to the platform
+5. **Apply** — All accepted proposals are pushed to the platform in one operation
+
+Use `--apply` to automatically apply after completion, or run `campaign status` to review before applying.

--- a/docs/src/cli/command-reference.md
+++ b/docs/src/cli/command-reference.md
@@ -100,6 +100,74 @@
 | `pretorin config set <key> <value>` | Set a config value |
 | `pretorin config path` | Show config file path |
 
+## Campaign Commands
+
+| Command | Description |
+|---------|-------------|
+| `pretorin campaign controls` | Run bulk control narrative/evidence campaign (`--mode`, `--family`, `--controls`, `--all-controls`, `--artifacts`, `--review-job`, `--concurrency`, `--checkpoint`, `--apply`, `--output`) |
+| `pretorin campaign policy` | Run bulk policy questionnaire campaign (`--mode`, `--policies`, `--all-incomplete`, `--concurrency`, `--checkpoint`, `--apply`, `--output`) |
+| `pretorin campaign scope` | Run bulk scope questionnaire campaign (`--mode`, `--system`, `--framework-id`, `--concurrency`, `--checkpoint`, `--apply`, `--output`) |
+| `pretorin campaign status` | Show campaign progress from a checkpoint file (`--checkpoint`, `--output`) |
+
+### Campaign Modes
+
+| Domain | Mode | Description |
+|--------|------|-------------|
+| controls | `initial` | Draft new narratives and evidence for controls |
+| controls | `notes-fix` | Address platform notes on existing controls |
+| controls | `review-fix` | Fix findings from a family review job |
+| policy | `answer` | Generate answers for policy questions |
+| policy | `review-fix` | Fix findings from a policy review |
+| scope | `answer` | Generate answers for scope questions |
+| scope | `review-fix` | Fix findings from a scope review |
+
+## Vendor Commands
+
+| Command | Description |
+|---------|-------------|
+| `pretorin vendor list` | List all vendors in the organization |
+| `pretorin vendor create <name>` | Create a vendor (`--type`, `--description`, `--authorization-level`) |
+| `pretorin vendor get <vendor_id>` | Get vendor details |
+| `pretorin vendor update <vendor_id>` | Update vendor fields (`--name`, `--description`, `--type`, `--authorization-level`) |
+| `pretorin vendor delete <vendor_id>` | Delete a vendor (`--force`) |
+| `pretorin vendor upload-doc <vendor_id> <file>` | Upload a vendor evidence document (`--name`, `--description`, `--attestation-type`) |
+| `pretorin vendor list-docs <vendor_id>` | List documents linked to a vendor |
+
+### Vendor Types
+
+`csp`, `saas`, `managed_service`, `internal`
+
+## STIG Commands
+
+| Command | Description |
+|---------|-------------|
+| `pretorin stig list` | List STIG benchmarks (`--technology-area`, `--product`, `--limit`) |
+| `pretorin stig show <stig_id>` | Show STIG benchmark detail with severity breakdown |
+| `pretorin stig rules <stig_id>` | List rules for a benchmark (`--severity`, `--cci`, `--limit`) |
+| `pretorin stig applicable` | Show applicable STIGs for the active system (`--system`) |
+| `pretorin stig infer` | AI-infer applicable STIGs from system profile (`--system`) |
+
+## CCI Commands
+
+| Command | Description |
+|---------|-------------|
+| `pretorin cci list` | List CCIs (`--control`, `--status`, `--limit`) |
+| `pretorin cci show <cci_id>` | Show CCI detail with linked SRGs and STIG rules (e.g., `CCI-000015`) |
+| `pretorin cci chain <control_id>` | Full traceability chain: Control -> CCIs -> SRGs -> STIG rules (`--system`) |
+
+## Scan Commands
+
+| Command | Description |
+|---------|-------------|
+| `pretorin scan doctor` | Check which scanner tools are installed and available |
+| `pretorin scan manifest` | Show test manifest for the active system (`--system`, `--stig`) |
+| `pretorin scan run` | Run STIG compliance scans (`--system`, `--stig`, `--tool`, `--dry-run`) |
+| `pretorin scan results` | Show CCI-level test results (`--system`, `--control`) |
+
+### Supported Scanners
+
+`OpenSCAP`, `InSpec`, `AWS Cloud Scanner`, `Azure Cloud Scanner`, `Manual`
+
 ## Deprecated Commands
 
 | Command | Description |

--- a/docs/src/cli/scanning.md
+++ b/docs/src/cli/scanning.md
@@ -1,0 +1,80 @@
+# STIG Scanning
+
+The `scan` command group runs STIG compliance scans using available scanner tools and manages test results.
+
+## Check Scanner Availability
+
+```bash
+pretorin scan doctor
+```
+
+Lists which scanner tools are installed and available on your system:
+
+| Scanner | Description |
+|---------|-------------|
+| OpenSCAP | Open-source SCAP scanner |
+| InSpec | Chef InSpec compliance profiles |
+| AWS Cloud Scanner | AWS-native compliance scanning |
+| Azure Cloud Scanner | Azure-native compliance scanning |
+| Manual | Manual review checklist |
+
+## View Test Manifest
+
+```bash
+# Uses active system context
+pretorin scan manifest
+
+# Filter by STIG
+pretorin scan manifest --system "My System" --stig <stig_id>
+```
+
+Shows which STIGs and rules are applicable to the system and which scanners can test them.
+
+## Run Scans
+
+```bash
+# Run all applicable scans
+pretorin scan run
+
+# Target a specific STIG
+pretorin scan run --stig <stig_id>
+
+# Use a specific scanner
+pretorin scan run --tool openscap
+
+# Dry run (show what would execute)
+pretorin scan run --dry-run
+```
+
+The scan orchestrator automatically detects available scanners, assigns rules to capable tools, and collects results.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--system` / `-s` | Target system (uses active context if omitted) |
+| `--stig` | Run only rules from this STIG benchmark |
+| `--tool` / `-t` | Force a specific scanner tool |
+| `--dry-run` | Show the test plan without executing |
+
+## View Results
+
+```bash
+# All results for active system
+pretorin scan results
+
+# Filter by control
+pretorin scan results --system "My System" --control ac-2
+```
+
+Shows CCI-level test results including pass/fail status, scanner used, and timestamp.
+
+## Workflow
+
+1. `pretorin scan doctor` — Verify scanner tools are installed
+2. `pretorin scan manifest` — Review what will be tested
+3. `pretorin scan run --dry-run` — Preview the test plan
+4. `pretorin scan run` — Execute scans
+5. `pretorin scan results` — Review results
+
+Results are automatically submitted to the platform when a system context is active.

--- a/docs/src/cli/stig-cci.md
+++ b/docs/src/cli/stig-cci.md
@@ -1,0 +1,79 @@
+# STIG & CCI Browsing
+
+The `stig` and `cci` command groups let you browse STIG benchmarks, rules, and CCIs with full traceability from NIST 800-53 controls down to individual STIG check rules.
+
+## STIG Commands
+
+### List STIG Benchmarks
+
+```bash
+pretorin stig list
+pretorin stig list --technology-area "Network"
+pretorin stig list --product "Windows" --limit 10
+```
+
+### Show STIG Details
+
+```bash
+pretorin stig show <stig_id>
+```
+
+Shows benchmark metadata including title, version, release info, and severity breakdown of rules.
+
+### List Rules for a STIG
+
+```bash
+pretorin stig rules <stig_id>
+pretorin stig rules <stig_id> --severity high
+pretorin stig rules <stig_id> --cci CCI-000015 --limit 20
+```
+
+### Show Applicable STIGs
+
+```bash
+# Uses active system context
+pretorin stig applicable
+
+# Explicit system
+pretorin stig applicable --system "My System"
+```
+
+### AI-Infer Applicable STIGs
+
+```bash
+pretorin stig infer
+pretorin stig infer --system "My System"
+```
+
+Uses the system's profile to recommend which STIG benchmarks should apply.
+
+## CCI Commands
+
+CCIs (Control Correlation Identifiers) bridge NIST 800-53 controls to specific STIG rules via SRGs (Security Requirements Guides).
+
+### List CCIs
+
+```bash
+pretorin cci list
+pretorin cci list --control ac-2
+pretorin cci list --status draft --limit 50
+```
+
+### Show CCI Details
+
+```bash
+pretorin cci show CCI-000015
+```
+
+Shows the CCI definition, linked SRGs, and linked STIG rules.
+
+### Full Traceability Chain
+
+```bash
+pretorin cci chain ac-2
+pretorin cci chain ac-2 --system "My System"
+```
+
+Shows the complete chain: **NIST 800-53 Control -> CCIs -> SRGs -> STIG rules** (and test results when `--system` is provided).
+
+This is useful for understanding exactly which technical checks validate a given control requirement.

--- a/docs/src/cli/vendors.md
+++ b/docs/src/cli/vendors.md
@@ -1,0 +1,77 @@
+# Vendor Management
+
+The `vendor` command group manages vendor entities and their evidence documents. Vendors represent external providers (CSPs, SaaS, managed services) or internal teams whose controls your system inherits.
+
+## List Vendors
+
+```bash
+pretorin vendor list
+```
+
+## Create a Vendor
+
+```bash
+pretorin vendor create "AWS" --type csp --description "Primary cloud provider" \
+  --authorization-level "FedRAMP High P-ATO"
+```
+
+### Vendor Types
+
+| Type | Description |
+|------|-------------|
+| `csp` | Cloud Service Provider |
+| `saas` | Software as a Service |
+| `managed_service` | Managed service provider |
+| `internal` | Internal team or shared service |
+
+## Get Vendor Details
+
+```bash
+pretorin vendor get <vendor_id>
+```
+
+## Update a Vendor
+
+```bash
+pretorin vendor update <vendor_id> --name "AWS GovCloud" --authorization-level "FedRAMP High"
+```
+
+## Delete a Vendor
+
+```bash
+pretorin vendor delete <vendor_id>
+pretorin vendor delete <vendor_id> --force  # skip confirmation
+```
+
+## Upload Vendor Documents
+
+Upload SOC 2 reports, Customer Responsibility Matrices (CRMs), FedRAMP packages, or other vendor evidence:
+
+```bash
+pretorin vendor upload-doc <vendor_id> ./aws-soc2-report.pdf \
+  --name "AWS SOC 2 Type II" \
+  --description "Annual SOC 2 report covering 2025" \
+  --attestation-type third_party_attestation
+```
+
+### Attestation Types
+
+| Type | Description |
+|------|-------------|
+| `self_attested` | Vendor's own assertion |
+| `third_party_attestation` | Independent auditor report (SOC 2, FedRAMP) |
+| `vendor_provided` | Documentation provided by vendor |
+
+## List Vendor Documents
+
+```bash
+pretorin vendor list-docs <vendor_id>
+```
+
+## Related: Control Inheritance
+
+Once vendors are created and documents uploaded, use the MCP tools or platform to set control responsibility edges:
+
+- `pretorin_set_control_responsibility` — Mark controls as inherited/shared
+- `pretorin_generate_inheritance_narrative` — AI-draft inheritance narratives from vendor docs
+- `pretorin_get_stale_edges` / `pretorin_sync_stale_edges` — Monitor and sync inheritance

--- a/docs/src/mcp/tools.md
+++ b/docs/src/mcp/tools.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-The MCP server provides 29 tools organized by category.
+The MCP server provides 80+ tools organized by category.
 
 ## Framework & Control Reference
 
@@ -381,3 +381,671 @@ Generate read-only AI drafts for a control narrative and evidence-gap assessment
 **Returns:** Draft narrative text plus evidence-gap analysis. Does not write to the platform.
 
 Use `pretorin_update_narrative`, `pretorin_create_evidence`, and `pretorin_add_control_note` to persist approved changes.
+
+---
+
+## Workflow State & Analytics
+
+### pretorin_get_workflow_state
+
+Get the lifecycle state for a system+framework, showing which stage needs work next (scope, policies, controls, evidence).
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Current workflow stage, completion percentages, and next recommended action.
+
+---
+
+### pretorin_get_analytics_summary
+
+Get a lightweight system progress snapshot.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Scope completion, policy completion, control coverage, and evidence gaps.
+
+---
+
+### pretorin_get_family_analytics
+
+Get per-family breakdown with narrative coverage, evidence coverage, and status distribution.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Per-family metrics.
+
+---
+
+### pretorin_get_policy_analytics
+
+Get per-policy breakdown with answer completion and review status.
+
+**Parameters:** None (uses org context)
+
+**Returns:** Per-policy completion metrics.
+
+---
+
+## Family Operations
+
+### pretorin_get_pending_families
+
+Identify which control families need work.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Families with counts of pending vs total controls.
+
+---
+
+### pretorin_get_family_bundle
+
+Get all controls in one family with status, narrative presence, evidence presence, and note counts.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `family_id` (required)
+
+**Returns:** Complete family bundle with per-control details.
+
+---
+
+### pretorin_trigger_family_review
+
+Trigger AI review of all controls in a family. Takes 2-4 minutes for large families.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `family_id` (required)
+
+**Returns:** Review job ID for polling.
+
+---
+
+### pretorin_get_family_review_results
+
+Poll family review results.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `job_id` (required)
+
+**Returns:** Aggregated findings with severity, affected control IDs, and recommended fixes.
+
+---
+
+## Scope Workflow
+
+### pretorin_get_pending_scope_questions
+
+Get only unanswered scope questions (lightweight).
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** List of unanswered questions with IDs.
+
+---
+
+### pretorin_get_scope_question_detail
+
+Get guidance, tips, and example responses for a specific scope question.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `question_id` (required)
+
+**Returns:** Question text, guidance, tips, and example answers.
+
+---
+
+### pretorin_answer_scope_question
+
+Answer one scope question.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `question_id` (required)
+- `answer` (required)
+
+**Returns:** Updated question state.
+
+---
+
+### pretorin_trigger_scope_generation
+
+Trigger AI generation of scope document from answered questions.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Generation job status.
+
+---
+
+### pretorin_trigger_scope_review
+
+Trigger AI review of scope answers.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Review job ID for polling.
+
+---
+
+### pretorin_get_scope_review_results
+
+Poll for structured scope review findings.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `job_id` (required)
+
+**Returns:** Findings with severity levels and recommended fixes.
+
+---
+
+## Policy Workflow
+
+### pretorin_get_pending_policy_questions
+
+Get only unanswered policy questions.
+
+**Parameters:**
+- `policy_id` (required)
+
+**Returns:** List of unanswered questions.
+
+---
+
+### pretorin_get_policy_question_detail
+
+Get guidance, tips, and examples for a specific policy question.
+
+**Parameters:**
+- `policy_id` (required)
+- `question_id` (required)
+
+**Returns:** Question text, guidance, and example answers.
+
+---
+
+### pretorin_answer_policy_question
+
+Answer one policy question.
+
+**Parameters:**
+- `policy_id` (required)
+- `question_id` (required)
+- `answer` (required)
+
+**Returns:** Updated question state.
+
+---
+
+### pretorin_get_policy_workflow_state
+
+Get per-policy workflow state including completion, generation, and review status.
+
+**Parameters:**
+- `policy_id` (required)
+
+**Returns:** Policy workflow state.
+
+---
+
+### pretorin_trigger_policy_generation
+
+Trigger AI generation of policy document from answered questions.
+
+**Parameters:**
+- `policy_id` (required)
+
+**Returns:** Generation job status.
+
+---
+
+### pretorin_trigger_policy_review
+
+Trigger AI review of policy answers/document.
+
+**Parameters:**
+- `policy_id` (required)
+
+**Returns:** Review job ID for polling.
+
+---
+
+### pretorin_get_policy_review_results
+
+Poll for structured policy review findings.
+
+**Parameters:**
+- `policy_id` (required)
+- `job_id` (required)
+
+**Returns:** Findings with severity levels and recommended fixes.
+
+---
+
+## Campaign Operations
+
+Campaigns enable bulk compliance operations with checkpoint persistence and lease-based concurrency.
+
+### pretorin_prepare_campaign
+
+Prepare a workflow-aligned campaign run with a platform state snapshot.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+- `domain` (required) — `controls`, `policy`, or `scope`
+- `mode` (required) — `initial`, `notes-fix`, `review-fix`, `answer`
+- `family_id` (optional) — Target family for control campaigns
+- `review_job` (optional) — Review job ID for `review-fix` mode
+
+**Returns:** Campaign checkpoint with item list and metadata.
+
+---
+
+### pretorin_claim_campaign_items
+
+Claim items for drafting with TTL-based leases. Safe for fan-out to multiple agents.
+
+**Parameters:**
+- `checkpoint` (required) — Campaign checkpoint
+- `count` (optional) — Number of items to claim
+
+**Returns:** Claimed items with lease metadata.
+
+---
+
+### pretorin_get_campaign_item_context
+
+Get full item context plus drafting instructions for a claimed item.
+
+**Parameters:**
+- `checkpoint` (required)
+- `item_id` (required)
+
+**Returns:** Control/policy/scope context, current state, and drafting guidance.
+
+---
+
+### pretorin_submit_campaign_proposal
+
+Submit an external agent's proposal without applying it to the platform.
+
+**Parameters:**
+- `checkpoint` (required)
+- `item_id` (required)
+- `proposal` (required) — Draft content
+
+**Returns:** Proposal acceptance confirmation.
+
+---
+
+### pretorin_apply_campaign
+
+Push all accepted proposals to the platform as a single apply operation.
+
+**Parameters:**
+- `checkpoint` (required)
+
+**Returns:** Apply results with per-item status.
+
+---
+
+### pretorin_get_campaign_status
+
+Get structured campaign status with a stable transcript snapshot.
+
+**Parameters:**
+- `checkpoint` (required)
+
+**Returns:** Campaign progress, item states, and transcript.
+
+---
+
+## Vendor Management
+
+### pretorin_list_vendors
+
+List all vendor entities in the organization.
+
+**Parameters:** None
+
+**Returns:** Vendor list with IDs, names, types, and authorization levels.
+
+---
+
+### pretorin_create_vendor
+
+Create a new vendor entity.
+
+**Parameters:**
+- `name` (required)
+- `vendor_type` (optional) — `csp`, `saas`, `managed_service`, `internal`
+- `description` (optional)
+- `authorization_level` (optional)
+
+**Returns:** Created vendor record.
+
+---
+
+### pretorin_get_vendor
+
+Get vendor details.
+
+**Parameters:**
+- `vendor_id` (required)
+
+**Returns:** Vendor metadata and linked documents.
+
+---
+
+### pretorin_update_vendor
+
+Update vendor fields.
+
+**Parameters:**
+- `vendor_id` (required)
+- `name` (optional)
+- `description` (optional)
+- `vendor_type` (optional)
+- `authorization_level` (optional)
+
+**Returns:** Updated vendor record.
+
+---
+
+### pretorin_delete_vendor
+
+Delete a vendor entity.
+
+**Parameters:**
+- `vendor_id` (required)
+
+**Returns:** Deletion confirmation.
+
+---
+
+### pretorin_upload_vendor_document
+
+Upload vendor evidence documents (SOC 2 reports, CRMs, FedRAMP packages).
+
+**Parameters:**
+- `vendor_id` (required)
+- `file_path` (required)
+- `name` (optional)
+- `description` (optional)
+- `attestation_type` (optional) — `self_attested`, `third_party_attestation`, `vendor_provided`
+
+**Returns:** Uploaded document record.
+
+---
+
+### pretorin_list_vendor_documents
+
+List documents linked to a vendor.
+
+**Parameters:**
+- `vendor_id` (required)
+
+**Returns:** Document list with metadata.
+
+---
+
+### pretorin_link_evidence_to_vendor
+
+Link an evidence item to a vendor with attestation type.
+
+**Parameters:**
+- `evidence_id` (required)
+- `vendor_id` (required)
+- `attestation_type` (optional)
+
+**Returns:** Link confirmation.
+
+---
+
+## Inheritance & Responsibility
+
+### pretorin_set_control_responsibility
+
+Mark a control as inherited or shared from a provider.
+
+**Parameters:**
+- `system_id` (required)
+- `control_id` (required)
+- `framework_id` (required)
+- `vendor_id` (required)
+- `responsibility_type` (required) — `inherited` or `shared`
+
+**Returns:** Created responsibility edge.
+
+---
+
+### pretorin_get_control_responsibility
+
+Check if a control is inherited and from where.
+
+**Parameters:**
+- `system_id` (required)
+- `control_id` (required)
+- `framework_id` (required)
+
+**Returns:** Responsibility edge details or null.
+
+---
+
+### pretorin_remove_control_responsibility
+
+Convert an inherited control back to system-specific.
+
+**Parameters:**
+- `system_id` (required)
+- `control_id` (required)
+- `framework_id` (required)
+
+**Returns:** Removal confirmation.
+
+---
+
+### pretorin_generate_inheritance_narrative
+
+AI-generate an inheritance narrative grounded in vendor documentation.
+
+**Parameters:**
+- `system_id` (required)
+- `control_id` (required)
+- `framework_id` (required)
+- `vendor_id` (required)
+
+**Returns:** Draft inheritance narrative text.
+
+---
+
+### pretorin_get_stale_edges
+
+Identify controls where the source narrative changed but the inherited control hasn't been updated.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** List of stale inheritance edges with source change timestamps.
+
+---
+
+### pretorin_sync_stale_edges
+
+Bulk update inherited controls by regenerating narratives from latest source.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Sync results with per-control status.
+
+---
+
+## STIG & CCI
+
+### pretorin_list_stigs
+
+List STIG benchmarks with optional filters.
+
+**Parameters:**
+- `technology_area` (optional) — Filter by technology area
+- `product` (optional) — Filter by product name
+- `limit` (optional)
+
+**Returns:** STIG benchmark list with IDs, titles, and rule counts.
+
+---
+
+### pretorin_get_stig
+
+Get STIG benchmark detail.
+
+**Parameters:**
+- `stig_id` (required)
+
+**Returns:** Benchmark metadata including title, version, release info, and severity breakdown.
+
+---
+
+### pretorin_list_stig_rules
+
+List rules for a STIG benchmark.
+
+**Parameters:**
+- `stig_id` (required)
+- `severity` (optional) — Filter by severity (high, medium, low)
+- `cci` (optional) — Filter by CCI ID
+- `limit` (optional)
+
+**Returns:** Rule list with IDs, titles, severities, and linked CCIs.
+
+---
+
+### pretorin_get_stig_rule
+
+Get full STIG rule detail.
+
+**Parameters:**
+- `rule_id` (required)
+
+**Returns:** Check text, fix text, discussion, and linked CCIs.
+
+---
+
+### pretorin_list_ccis
+
+List CCIs with optional filters.
+
+**Parameters:**
+- `control` (optional) — Filter by NIST 800-53 control ID
+- `status` (optional)
+- `limit` (optional)
+
+**Returns:** CCI list with definitions and linked controls.
+
+---
+
+### pretorin_get_cci
+
+Get CCI detail with linked SRGs and STIG rules.
+
+**Parameters:**
+- `cci_id` (required) — e.g., `CCI-000015`
+
+**Returns:** CCI definition, linked SRGs, and linked STIG rules.
+
+---
+
+### pretorin_get_cci_chain
+
+Get the full traceability chain: Control -> CCIs -> SRGs -> STIG rules.
+
+**Parameters:**
+- `control_id` (required) — NIST 800-53 control ID
+- `system_id` (optional) — Include test results when provided
+
+**Returns:** Complete traceability from control requirements to technical checks.
+
+---
+
+### pretorin_get_cci_status
+
+Get CCI-level compliance rollup for a system.
+
+**Parameters:**
+- `system_id` (required)
+- `framework_id` (required)
+
+**Returns:** Per-CCI pass/fail status.
+
+---
+
+### pretorin_get_stig_applicability
+
+Get which STIGs apply to a system based on its profile.
+
+**Parameters:**
+- `system_id` (required)
+
+**Returns:** List of applicable STIG benchmarks.
+
+---
+
+### pretorin_infer_stigs
+
+AI-infer applicable STIGs from the system's profile.
+
+**Parameters:**
+- `system_id` (required)
+
+**Returns:** Recommended STIG benchmarks with reasoning.
+
+---
+
+### pretorin_get_test_manifest
+
+Fetch the test manifest (applicable STIGs + rules) for a system.
+
+**Parameters:**
+- `system_id` (required)
+
+**Returns:** Test manifest with applicable rules and scanner assignments.
+
+---
+
+### pretorin_submit_test_results
+
+Upload STIG scan results to the platform.
+
+**Parameters:**
+- `system_id` (required)
+- `results` (required) — Scan result payload
+
+**Returns:** Submission confirmation with per-result status.

--- a/docs/src/reference/changelog.md
+++ b/docs/src/reference/changelog.md
@@ -2,6 +2,56 @@
 
 All notable changes to the Pretorin CLI are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-04-07
+
+### Added
+- `pretorin_get_stig` MCP tool for STIG benchmark detail
+- `pretorin_get_cci_chain` MCP tool for full Control → CCI → SRG → STIG rule traceability
+
+---
+
+## [0.13.0] - 2026-04-07
+
+### Added
+- Complete STIG/CCI MCP tools: `list_stigs`, `get_stig`, `list_stig_rules`, `get_stig_rule`, `list_ccis`, `get_cci`, `get_cci_chain`, `get_cci_status`, `get_stig_applicability`, `infer_stigs`, `get_test_manifest`, `submit_test_results`
+- STIG/CCI agent tools for OpenAI Agents SDK
+- `pretorin stig` CLI group: `list`, `show`, `rules`, `applicable`, `infer`
+- `pretorin cci` CLI group: `list`, `show`, `chain`
+- `pretorin scan` CLI group: `doctor`, `manifest`, `run`, `results`
+- Scanner orchestration module with support for OpenSCAP, InSpec, AWS/Azure Cloud Scanners, and Manual review
+
+---
+
+## [0.12.0] - 2026-04-04
+
+### Added
+- Vendor management CLI: `pretorin vendor list/create/get/update/delete/upload-doc/list-docs`
+- MCP vendor tools: `list_vendors`, `create_vendor`, `get_vendor`, `update_vendor`, `delete_vendor`, `upload_vendor_document`, `list_vendor_documents`, `link_evidence_to_vendor`
+- Inheritance/responsibility MCP tools: `set_control_responsibility`, `get_control_responsibility`, `remove_control_responsibility`, `generate_inheritance_narrative`, `get_stale_edges`, `sync_stale_edges`
+
+---
+
+## [0.11.0] - 2026-04-01
+
+### Added
+- Campaign CLI: `pretorin campaign controls/policy/scope/status`
+- Campaign MCP tools: `prepare_campaign`, `claim_campaign_items`, `get_campaign_item_context`, `submit_campaign_proposal`, `apply_campaign`, `get_campaign_status`
+- External-agent-first campaign pattern with checkpoint persistence and lease-based concurrency
+- Campaign builtin executor for local execution
+
+---
+
+## [0.10.0] - 2026-03-28
+
+### Added
+- Workflow state and analytics MCP tools: `get_workflow_state`, `get_analytics_summary`, `get_family_analytics`, `get_policy_analytics`
+- Family operations MCP tools: `get_pending_families`, `get_family_bundle`, `trigger_family_review`, `get_family_review_results`
+- Policy workflow MCP tools: `get_pending_policy_questions`, `get_policy_question_detail`, `answer_policy_question`, `get_policy_workflow_state`, `trigger_policy_generation`, `trigger_policy_review`, `get_policy_review_results`
+- Scope workflow MCP tools: `get_pending_scope_questions`, `get_scope_question_detail`, `answer_scope_question`, `trigger_scope_generation`, `trigger_scope_review`, `get_scope_review_results`
+- ExecutionScope for thread-safe parallel agent execution
+
+---
+
 ## [0.9.7] - 2026-03-25
 
 ### Fixed
@@ -184,6 +234,12 @@ All notable changes to the Pretorin CLI are documented here. The format is based
 - FedRAMP (Low, Moderate, High)
 - CMMC Level 1, 2, and 3
 
+[0.13.1]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.9.7...v0.10.0
+[0.9.7]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.7...v0.9.7
 [0.8.7]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.8.0...v0.8.5

--- a/docs/src/workflows/campaigns.md
+++ b/docs/src/workflows/campaigns.md
@@ -1,0 +1,94 @@
+# Campaign Workflows
+
+Campaigns are the recommended way to run bulk compliance operations across multiple controls, policies, or scope questions. They replace manual one-at-a-time updates with a coordinated prepare-claim-propose-apply lifecycle.
+
+## When to Use Campaigns
+
+- **Initial control implementation** — Draft narratives and evidence for an entire control family
+- **Fixing review findings** — Address issues flagged by family or policy reviews
+- **Answering questionnaires** — Bulk-answer policy or scope questions
+- **Notes remediation** — Fix controls flagged by platform notes
+
+## Campaign Lifecycle
+
+```
+Prepare → Claim → Draft → Propose → Apply
+```
+
+1. **Prepare** — Snapshot platform state and create a checkpoint file. This captures the current state of all target items so the campaign works from a consistent baseline.
+
+2. **Claim** — Lease items for drafting. TTL-based leases prevent concurrent editing when multiple agents are working in parallel.
+
+3. **Draft** — For each claimed item, get full context (control requirements, current state, guidance) and produce a draft.
+
+4. **Propose** — Submit drafts as proposals without writing to the platform. This provides a review opportunity before any changes are persisted.
+
+5. **Apply** — Push all accepted proposals to the platform as a single operation.
+
+## External Agent Pattern
+
+Campaigns are designed for external agents (Claude Code, Codex, Cursor, etc.) operating through MCP:
+
+```
+Agent A: prepare_campaign → claim_campaign_items → get_campaign_item_context → submit_campaign_proposal
+Agent B: claim_campaign_items → get_campaign_item_context → submit_campaign_proposal
+...
+Coordinator: get_campaign_status → apply_campaign
+```
+
+The checkpoint file enables independent agent execution. Agents can claim non-overlapping items and work in parallel.
+
+## CLI Usage
+
+### Control Campaign
+
+```bash
+# Draft narratives for the Access Control family
+pretorin campaign controls --mode initial --family AC \
+  --system "My System" --framework-id fedramp-moderate
+
+# Fix controls flagged by notes
+pretorin campaign controls --mode notes-fix --family AC
+
+# Fix controls flagged by review
+pretorin campaign controls --mode review-fix --family AC --review-job <job-id>
+
+# Auto-apply after completion
+pretorin campaign controls --mode initial --family AC --apply
+```
+
+### Policy Campaign
+
+```bash
+# Answer all incomplete policy questions
+pretorin campaign policy --mode answer --all-incomplete
+
+# Fix review findings for a specific policy
+pretorin campaign policy --mode review-fix --policies <policy-id>
+```
+
+### Scope Campaign
+
+```bash
+pretorin campaign scope --mode answer \
+  --system "My System" --framework-id fedramp-moderate
+```
+
+### Check Status
+
+```bash
+pretorin campaign status --checkpoint .pretorin/campaign-checkpoint.json
+```
+
+## MCP Tool Sequence
+
+For AI agents working through MCP:
+
+1. `pretorin_get_workflow_state` — Understand what needs work
+2. `pretorin_get_pending_families` — Identify target families
+3. `pretorin_prepare_campaign` — Create the campaign
+4. `pretorin_claim_campaign_items` — Claim items
+5. `pretorin_get_campaign_item_context` — Get context per item
+6. `pretorin_submit_campaign_proposal` — Submit drafts
+7. `pretorin_get_campaign_status` — Review progress
+8. `pretorin_apply_campaign` — Push to platform

--- a/docs/src/workflows/policy-scope.md
+++ b/docs/src/workflows/policy-scope.md
@@ -1,0 +1,124 @@
+# Policy & Scope Questionnaires
+
+Pretorin uses questionnaire workflows to capture organizational policy information and system scope details. Both follow a similar lifecycle: answer questions, generate documents, review, and iterate.
+
+## Policy Questionnaire Workflow
+
+Organization policies (e.g., Access Control Policy, Incident Response Policy) are defined at the org level and apply across systems.
+
+### 1. List Available Policies
+
+```bash
+pretorin policy list
+```
+
+Or via MCP: `pretorin_list_org_policies`
+
+### 2. View Pending Questions
+
+```bash
+# Via MCP
+pretorin_get_pending_policy_questions  # lightweight — only unanswered
+pretorin_get_policy_question_detail    # guidance and examples per question
+```
+
+### 3. Answer Questions
+
+Answer individually for precise control:
+
+```
+pretorin_answer_policy_question(policy_id, question_id, answer)
+```
+
+Or batch-update multiple answers:
+
+```
+pretorin_patch_org_policy_qa(policy_id, updates=[{question_id, answer}, ...])
+```
+
+### 4. Generate Policy Document
+
+Once questions are answered, trigger AI document generation:
+
+```
+pretorin_trigger_policy_generation(policy_id)
+```
+
+### 5. Review
+
+Trigger an AI review of the policy:
+
+```
+pretorin_trigger_policy_review(policy_id)
+pretorin_get_policy_review_results(policy_id)  # poll for results
+```
+
+Review results include findings with severity levels, affected sections, and recommended fixes.
+
+### 6. Track Status
+
+```
+pretorin_get_policy_workflow_state(policy_id)
+pretorin_get_policy_analytics()
+```
+
+## Scope Questionnaire Workflow
+
+Scope questionnaires are system+framework specific. They define what's in scope, what's excluded, and system boundary details.
+
+### 1. View Pending Questions
+
+```
+pretorin_get_pending_scope_questions(system_id, framework_id)
+pretorin_get_scope_question_detail(system_id, framework_id, question_id)
+```
+
+### 2. Answer Questions
+
+```
+pretorin_answer_scope_question(system_id, framework_id, question_id, answer)
+```
+
+Or batch-update:
+
+```
+pretorin_patch_scope_qa(system_id, framework_id, updates=[{question_id, answer}, ...])
+```
+
+### 3. Generate Scope Document
+
+```
+pretorin_trigger_scope_generation(system_id, framework_id)
+```
+
+### 4. Review
+
+```
+pretorin_trigger_scope_review(system_id, framework_id)
+pretorin_get_scope_review_results(system_id, framework_id)
+```
+
+### 5. View Full Scope
+
+```
+pretorin_get_scope(system_id, framework_id)
+```
+
+Returns scope narrative, excluded controls, and Q&A responses.
+
+## Bulk Questionnaire Campaigns
+
+For answering many questions at once, use campaigns:
+
+```bash
+# Answer all incomplete policy questions
+pretorin campaign policy --mode answer --all-incomplete
+
+# Answer scope questions
+pretorin campaign scope --mode answer --system "My System" --framework-id fedramp-moderate
+
+# Fix review findings
+pretorin campaign policy --mode review-fix --policies <policy-id>
+```
+
+See [Campaign Workflows](./campaigns.md) for details on the campaign lifecycle.

--- a/docs/src/workflows/stig-scanning.md
+++ b/docs/src/workflows/stig-scanning.md
@@ -1,0 +1,107 @@
+# STIG Compliance Scanning
+
+Pretorin integrates STIG (Security Technical Implementation Guide) scanning to verify technical control implementations. The scanning workflow connects NIST 800-53 controls to specific technical checks via the CCI (Control Correlation Identifier) chain.
+
+## Traceability Chain
+
+```
+NIST 800-53 Control → CCIs → SRGs → STIG Rules → Scanner Results
+```
+
+- **CCI** — Control Correlation Identifier: bridges a control requirement to testable items
+- **SRG** — Security Requirements Guide: technology-neutral security requirements
+- **STIG Rule** — Technology-specific check with detailed test and fix procedures
+
+## Browse the Chain
+
+### Find Applicable STIGs
+
+```bash
+# Show STIGs applicable to your system
+pretorin stig applicable --system "My System"
+
+# AI-infer STIGs from system profile
+pretorin stig infer --system "My System"
+```
+
+### Explore the Traceability
+
+```bash
+# Full chain from a NIST control to STIG rules
+pretorin cci chain ac-2 --system "My System"
+
+# Browse CCIs for a control
+pretorin cci list --control ac-2
+
+# See what a specific CCI requires
+pretorin cci show CCI-000015
+
+# Browse STIG rules
+pretorin stig rules <stig_id> --severity high
+```
+
+## Scanning Workflow
+
+### 1. Check Scanner Availability
+
+```bash
+pretorin scan doctor
+```
+
+Supported scanners: OpenSCAP, InSpec, AWS Cloud Scanner, Azure Cloud Scanner, Manual.
+
+### 2. Review Test Manifest
+
+```bash
+pretorin scan manifest --system "My System"
+```
+
+Shows which STIGs, rules, and scanners apply to the system.
+
+### 3. Run Scans
+
+```bash
+# Run all applicable scans
+pretorin scan run --system "My System"
+
+# Dry run first
+pretorin scan run --system "My System" --dry-run
+
+# Target specific STIG or tool
+pretorin scan run --stig <stig_id> --tool openscap
+```
+
+### 4. Review Results
+
+```bash
+# All results
+pretorin scan results --system "My System"
+
+# Filter by control
+pretorin scan results --system "My System" --control ac-2
+```
+
+### 5. Submit Results to Platform
+
+Results are automatically submitted when scanning with an active system context. For manual submission via MCP:
+
+```
+pretorin_submit_test_results(system_id, results)
+```
+
+## MCP Tools for STIG/CCI
+
+| Tool | Description |
+|------|-------------|
+| `pretorin_list_stigs` | List benchmarks with filters |
+| `pretorin_get_stig` | Benchmark detail |
+| `pretorin_list_stig_rules` | Rules with severity/CCI filters |
+| `pretorin_get_stig_rule` | Full rule: check text, fix text, CCIs |
+| `pretorin_list_ccis` | CCIs with control filter |
+| `pretorin_get_cci` | CCI detail with linked rules |
+| `pretorin_get_cci_chain` | Full traceability chain |
+| `pretorin_get_cci_status` | CCI compliance rollup |
+| `pretorin_get_stig_applicability` | Applicable STIGs for a system |
+| `pretorin_infer_stigs` | AI-infer applicable STIGs |
+| `pretorin_get_test_manifest` | Test manifest for a system |
+| `pretorin_submit_test_results` | Upload scan results |

--- a/docs/src/workflows/vendor-inheritance.md
+++ b/docs/src/workflows/vendor-inheritance.md
@@ -1,0 +1,80 @@
+# Vendor Inheritance
+
+Many compliance controls are partially or fully satisfied by external providers (cloud platforms, SaaS tools, managed services). Pretorin tracks these inheritance relationships and keeps inherited narratives in sync with vendor documentation.
+
+## Concepts
+
+- **Vendor** — An external provider or internal shared service (CSP, SaaS, managed service, internal)
+- **Responsibility edge** — A link between a control and a vendor indicating the control is inherited or shared
+- **Stale edge** — A responsibility edge where the source narrative has changed but the inherited control hasn't been updated
+
+## Workflow
+
+### 1. Create Vendor Entities
+
+```bash
+pretorin vendor create "AWS GovCloud" --type csp \
+  --description "Primary cloud infrastructure" \
+  --authorization-level "FedRAMP High P-ATO"
+
+pretorin vendor create "Okta" --type saas \
+  --description "Identity and access management"
+```
+
+### 2. Upload Vendor Documentation
+
+```bash
+pretorin vendor upload-doc <vendor_id> ./aws-crm.pdf \
+  --name "AWS Customer Responsibility Matrix" \
+  --attestation-type vendor_provided
+
+pretorin vendor upload-doc <vendor_id> ./okta-soc2.pdf \
+  --name "Okta SOC 2 Type II Report" \
+  --attestation-type third_party_attestation
+```
+
+### 3. Set Control Responsibility
+
+Via MCP tools:
+
+```
+pretorin_set_control_responsibility(system_id, control_id, framework_id, vendor_id, responsibility_type)
+```
+
+Responsibility types:
+- **inherited** — Fully satisfied by the vendor
+- **shared** — Partially satisfied; your system handles the remainder
+
+### 4. Generate Inheritance Narratives
+
+```
+pretorin_generate_inheritance_narrative(system_id, control_id, framework_id, vendor_id)
+```
+
+AI generates a narrative grounded in the vendor's uploaded documentation, explaining how the vendor satisfies the control requirements.
+
+### 5. Monitor Staleness
+
+Over time, vendor documentation or source narratives may be updated. Check for stale inheritance:
+
+```
+pretorin_get_stale_edges(system_id, framework_id)
+```
+
+Returns controls where the source has changed but the inherited narrative hasn't been refreshed.
+
+### 6. Sync Stale Edges
+
+```
+pretorin_sync_stale_edges(system_id, framework_id)
+```
+
+Bulk updates inherited controls by regenerating narratives from the latest source.
+
+## Linking Evidence to Vendors
+
+```
+pretorin_link_evidence_to_vendor(evidence_id, vendor_id, attestation_type)
+```
+
+Attestation types: `self_attested`, `third_party_attestation`, `vendor_provided`

--- a/pretorin-skill/SKILL.md
+++ b/pretorin-skill/SKILL.md
@@ -3,17 +3,20 @@ name: pretorin
 description: >
   This skill should be used when the user asks about compliance frameworks,
   security controls, control families, document requirements, FedRAMP, NIST 800-53,
-  NIST 800-171, CMMC, or wants to perform a compliance gap analysis, generate
-  compliance artifacts, map controls across frameworks, or check what documents
-  are needed for certification. Trigger phrases include "list frameworks",
-  "show controls", "what documents do I need", "compliance check",
-  "control requirements", "gap analysis", and "audit my code".
-version: 0.9.7
+  NIST 800-171, CMMC, STIGs, CCIs, vendor inheritance, compliance campaigns,
+  policy/scope questionnaires, or wants to perform a compliance gap analysis,
+  generate compliance artifacts, map controls across frameworks, run bulk
+  compliance workflows, manage vendor responsibility, scan for STIG compliance,
+  or check what documents are needed for certification. Trigger phrases include
+  "list frameworks", "show controls", "what documents do I need", "compliance check",
+  "control requirements", "gap analysis", "audit my code", "run campaign",
+  "vendor inheritance", "STIG rules", "CCI chain", and "scan compliance".
+version: 0.13.1
 ---
 
 # Pretorin Compliance Skill
 
-Query authoritative compliance framework data via the Pretorin MCP server. Access controls, families, document requirements, and implementation guidance from NIST 800-53, NIST 800-171, FedRAMP, and CMMC.
+Query authoritative compliance framework data via the Pretorin MCP server. Access controls, families, document requirements, implementation guidance, STIG/CCI traceability, vendor inheritance, and campaign-based bulk workflows across NIST 800-53, NIST 800-171, FedRAMP (Low/Moderate/High), and CMMC (Level 1/2/3).
 
 ## Prerequisites
 
@@ -90,6 +93,104 @@ When unsure of an ID, discover it first with `pretorin_list_control_families` or
 - **`pretorin_generate_control_artifacts`** — Generate read-only AI drafts for a control narrative and evidence-gap assessment using the same Codex workflow as the CLI. Use this when the user wants a draft without writing to the platform yet.
 - **`pretorin_push_monitoring_event`** — Record a monitoring event for notable findings such as scans, access reviews, or configuration changes.
 - **`pretorin_update_control_status`** — Update a control implementation status when findings justify a state change.
+
+### Batch Operations
+- **`pretorin_get_controls_batch`** — Get detailed control data for many controls in one framework-scoped request. Pass `framework_id` and optionally `control_ids` (omit to get all).
+- **`pretorin_create_evidence_batch`** — Create and link multiple evidence items within one system/framework scope. Pass `system_id`, `framework_id`, and `items` array.
+
+### Workflow State & Analytics
+- **`pretorin_get_workflow_state`** — Get lifecycle state for a system+framework showing which stage needs work (scope, policies, controls, evidence) and the next recommended action.
+- **`pretorin_get_analytics_summary`** — Lightweight system progress snapshot: scope completion, policy completion, control coverage, evidence gaps.
+- **`pretorin_get_family_analytics`** — Per-family breakdown with narrative coverage, evidence coverage, and status distribution.
+- **`pretorin_get_policy_analytics`** — Per-policy breakdown with answer completion and review status.
+
+### Family Operations
+- **`pretorin_get_pending_families`** — Identify which control families need work (returns counts of pending vs total controls).
+- **`pretorin_get_family_bundle`** — Get all controls in one family with status, narrative presence, evidence presence, and note counts.
+- **`pretorin_trigger_family_review`** — Trigger AI review of all controls in a family (2-4 minutes for large families). Returns a job ID.
+- **`pretorin_get_family_review_results`** — Poll family review results with aggregated findings showing severity, affected control IDs, and recommended fixes.
+
+### Scope Workflow
+- **`pretorin_get_pending_scope_questions`** — Get only unanswered scope questions (lightweight).
+- **`pretorin_get_scope_question_detail`** — Get guidance, tips, and examples for a specific scope question.
+- **`pretorin_answer_scope_question`** — Answer one scope question with partial update support.
+- **`pretorin_trigger_scope_generation`** — Trigger AI generation of scope document from answered questions.
+- **`pretorin_trigger_scope_review`** — Trigger AI review of scope answers.
+- **`pretorin_get_scope_review_results`** — Poll for structured scope review findings.
+
+### Policy Workflow
+- **`pretorin_get_pending_policy_questions`** — Get only unanswered policy questions.
+- **`pretorin_get_policy_question_detail`** — Get guidance, tips, and examples for a specific policy question.
+- **`pretorin_answer_policy_question`** — Answer one policy question.
+- **`pretorin_get_policy_workflow_state`** — Check per-policy completion status, document generation, and review status.
+- **`pretorin_trigger_policy_generation`** — Trigger AI generation of policy document from answered questions.
+- **`pretorin_trigger_policy_review`** — Trigger AI review of policy answers/document.
+- **`pretorin_get_policy_review_results`** — Poll for structured policy review findings.
+
+### Campaign Operations
+Campaigns enable bulk compliance operations across multiple controls, policies, or scope questions with checkpoint persistence and lease-based concurrency.
+
+- **`pretorin_prepare_campaign`** — Prepare a workflow-aligned campaign run with platform context snapshot.
+- **`pretorin_claim_campaign_items`** — Claim items for drafting with TTL-based leases.
+- **`pretorin_get_campaign_item_context`** — Get full item context plus drafting instructions.
+- **`pretorin_submit_campaign_proposal`** — Submit a proposal without applying to the platform.
+- **`pretorin_apply_campaign`** — Push accepted proposals to the platform.
+- **`pretorin_get_campaign_status`** — Get structured campaign status snapshot.
+
+### Vendor Management
+- **`pretorin_list_vendors`** — List all vendor entities (CSP, SaaS, managed services, internal).
+- **`pretorin_create_vendor`** — Create a new vendor entity.
+- **`pretorin_get_vendor`** — Get vendor details.
+- **`pretorin_update_vendor`** — Update vendor fields.
+- **`pretorin_delete_vendor`** — Delete a vendor entity.
+- **`pretorin_upload_vendor_document`** — Upload vendor evidence documents.
+- **`pretorin_list_vendor_documents`** — List documents linked to a vendor.
+- **`pretorin_link_evidence_to_vendor`** — Link evidence to a vendor with attestation type.
+
+### Inheritance & Responsibility
+- **`pretorin_set_control_responsibility`** — Mark a control as inherited/shared from a provider.
+- **`pretorin_get_control_responsibility`** — Check if a control is inherited and from where.
+- **`pretorin_remove_control_responsibility`** — Convert inherited control to system-specific.
+- **`pretorin_generate_inheritance_narrative`** — AI-generate inheritance narrative from vendor docs.
+- **`pretorin_get_stale_edges`** — Identify controls with stale inheritance.
+- **`pretorin_sync_stale_edges`** — Bulk update inherited controls from source narratives.
+
+### STIG & CCI
+- **`pretorin_list_stigs`** — List STIG benchmarks, filterable by technology area or product.
+- **`pretorin_get_stig`** — Get STIG benchmark details.
+- **`pretorin_list_stig_rules`** — List rules for a benchmark with severity/CCI filters.
+- **`pretorin_get_stig_rule`** — Get full rule detail: check text, fix text, linked CCIs.
+- **`pretorin_list_ccis`** — List CCI items, filterable by NIST 800-53 control.
+- **`pretorin_get_cci`** — Get CCI detail with linked SRGs and STIG rules.
+- **`pretorin_get_cci_chain`** — Full traceability: Control -> CCIs -> SRGs -> STIG rules.
+- **`pretorin_get_cci_status`** — CCI-level compliance rollup for a system.
+- **`pretorin_get_stig_applicability`** — Which STIGs apply to a system.
+- **`pretorin_infer_stigs`** — AI-infer applicable STIGs from system profile.
+- **`pretorin_get_test_manifest`** — Fetch test manifest for a system.
+- **`pretorin_submit_test_results`** — Upload STIG scan results.
+
+## Campaign Workflow
+
+For bulk compliance operations, follow this lifecycle:
+
+1. Check what needs work: `pretorin_get_workflow_state` and `pretorin_get_pending_families`
+2. Prepare the campaign: `pretorin_prepare_campaign` with the target domain (controls, policy, or scope) and mode
+3. Claim items: `pretorin_claim_campaign_items` to lease items for drafting
+4. Get context: `pretorin_get_campaign_item_context` for each claimed item
+5. Draft and submit: `pretorin_submit_campaign_proposal` for each item
+6. Review status: `pretorin_get_campaign_status` to check progress
+7. Apply: `pretorin_apply_campaign` to push all proposals to the platform
+
+## Vendor Inheritance Workflow
+
+For controls inherited from vendors (CSPs, SaaS providers):
+
+1. Create the vendor: `pretorin_create_vendor`
+2. Upload vendor documentation: `pretorin_upload_vendor_document` (SOC 2 reports, CRMs, FedRAMP packages)
+3. Set responsibility: `pretorin_set_control_responsibility` to mark controls as inherited/shared
+4. Generate narratives: `pretorin_generate_inheritance_narrative` to AI-draft grounded inheritance narratives
+5. Monitor staleness: `pretorin_get_stale_edges` to find controls where source narratives changed
+6. Sync updates: `pretorin_sync_stale_edges` to bulk update inherited controls
 
 ## Narrative + Evidence + Notes Workflow
 


### PR DESCRIPTION
## Summary
- Adds documentation for campaigns, vendor management/inheritance, STIG/CCI browsing, scanner orchestration, policy/scope questionnaire workflows, family operations, workflow state tracking, and analytics
- Updates README, CLI reference, MCP tool reference (29 → 80+ tools), SKILL.md (version 0.9.7 → 0.13.1), changelog, and book summary
- Creates 8 new doc pages: CLI references for campaigns, vendors, STIG/CCI, scanning + workflow guides for campaigns, policy/scope, vendor inheritance, STIG scanning

## Files changed (16)
- **Modified (8):** README.md, docs/CLI.md, docs/MCP.md, docs/src/SUMMARY.md, docs/src/cli/command-reference.md, docs/src/mcp/tools.md, docs/src/reference/changelog.md, pretorin-skill/SKILL.md
- **Created (8):** docs/src/cli/campaigns.md, docs/src/cli/vendors.md, docs/src/cli/stig-cci.md, docs/src/cli/scanning.md, docs/src/workflows/campaigns.md, docs/src/workflows/policy-scope.md, docs/src/workflows/vendor-inheritance.md, docs/src/workflows/stig-scanning.md

## Test plan
- [ ] Verify `cd docs && mdbook build` completes without errors
- [ ] Spot-check new pages render correctly in mdbook
- [ ] Verify SKILL.md loads correctly via `pretorin skill status`
- [ ] Confirm changelog version links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)