### PR TITLE
fix: apply_campaign response shows apply: true after apply

### DIFF
--- a/src/pretorin/workflows/campaign.py
+++ b/src/pretorin/workflows/campaign.py
@@ -669,6 +669,7 @@ def build_campaign_summary(
     *,
     output_mode: str | None = None,
     prepared_only: bool = False,
+    apply_override: bool | None = None,
 ) -> CampaignRunSummary:
     """Build a campaign summary from a checkpoint."""
     counts = _status_counts(checkpoint)
@@ -677,7 +678,7 @@ def build_campaign_summary(
     return CampaignRunSummary(
         domain=str(checkpoint.identity.get("domain", request.domain)),
         mode=str(checkpoint.identity.get("mode", request.mode)),
-        apply=bool(checkpoint.identity.get("apply", request.apply)),
+        apply=apply_override if apply_override is not None else bool(checkpoint.identity.get("apply", request.apply)),
         output_mode=output_mode or checkpoint.output,
         checkpoint_path=str(checkpoint_path),
         workflow_snapshot=checkpoint.workflow_snapshot,
@@ -1423,7 +1424,10 @@ async def apply_campaign(
             _record_event(checkpoint, presenter, "item_failed", str(exc), item=item)
         _write_checkpoint(checkpoint_path, checkpoint)
 
-    return build_campaign_summary(checkpoint, checkpoint_path, output_mode=request.output)
+    checkpoint.identity["apply"] = True
+    _write_checkpoint(checkpoint_path, checkpoint)
+
+    return build_campaign_summary(checkpoint, checkpoint_path, output_mode=request.output, apply_override=True)
 
 
 def _mark_item_failed(

--- a/tests/test_campaign_cli.py
+++ b/tests/test_campaign_cli.py
@@ -478,6 +478,9 @@ async def test_prepare_claim_submit_apply_policy_campaign(tmp_path: Path) -> Non
     summary = await apply_campaign(client, request.checkpoint_path)
 
     assert summary.succeeded == 1
+    assert summary.apply is True
+    status = get_campaign_status(request.checkpoint_path)
+    assert status.apply is True
     client.patch_org_policy_qa.assert_awaited_once_with(
         "pol-001",
         [{"question_id": "q_scope_2", "answer": "Production systems, CUI, administrators, and service accounts."}],


### PR DESCRIPTION
## Summary

Fixes #58

- `apply_campaign` response now shows `apply: true` instead of echoing the stale `prepare_campaign` default (`false`)
- Updates `checkpoint.identity["apply"]` after applying items, fixing downstream readers (`get_campaign_status`, `get_campaign_item_context`)
- Adds `apply_override` param to `build_campaign_summary()` for the immediate response

## Test plan

- [x] `test_prepare_claim_submit_apply_policy_campaign` asserts `summary.apply is True`
- [x] Same test asserts `get_campaign_status().apply is True` (verifies checkpoint persistence)
- [x] Full test suite passes (1160 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)