### PR TITLE
Merge #59/#61 and implement #62 for 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Pretorin CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-04-10
+
+### Changed
+- MCP and agent write workflows now treat the active CLI context as a strict execution boundary by default, with an explicit `allow_scope_override` escape hatch for intentional cross-scope writes
+- Control-scoped MCP and agent workflows now route through one shared scope-validation path so exact control lookup happens in the resolved framework before any write proceeds
+- Agent guidance now tells built-in workflows to resolve an exact user-supplied control in the active framework before doing broader discovery
+- `pretorin mcp-serve` now emits a non-blocking stderr update prompt when a newer CLI release is available, so MCP-only users can discover upgrades without interrupting active tool calls
+
+### Fixed
+- `apply_campaign` now reports `apply: true` after a successful apply run and persists that state back to the checkpoint summary
+- Stored active context and campaign checkpoints are now validated against the current API environment before campaign reads or writes proceed
+- Control-scoped MCP and agent updates now refuse silent remaps like `cm-04.02` to a different control when the exact control does not resolve in the active framework
+
+### Added
+- `pretorin_get_cli_status` and the `status://cli` MCP resource expose local CLI version, update availability, and upgrade guidance to MCP hosts and agents
+
 ## [0.11.0] - 2026-04-02
 
 ### Added

--- a/docs/src/reference/changelog.md
+++ b/docs/src/reference/changelog.md
@@ -2,6 +2,24 @@
 
 All notable changes to the Pretorin CLI are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-04-10
+
+### Changed
+- MCP and agent write workflows now treat the active CLI context as a strict execution boundary by default, with an explicit `allow_scope_override` escape hatch for intentional cross-scope writes
+- Control-scoped MCP and agent workflows now route through one shared scope-validation path so exact control lookup happens in the resolved framework before any write proceeds
+- Agent guidance now tells built-in workflows to resolve an exact user-supplied control in the active framework before doing broader discovery
+- `pretorin mcp-serve` now emits a non-blocking stderr update prompt when a newer CLI release is available, so MCP-only users can discover upgrades without interrupting active tool calls
+
+### Fixed
+- `apply_campaign` now reports `apply: true` after a successful apply run and persists that state back to the checkpoint summary
+- Stored active context and campaign checkpoints are now validated against the current API environment before campaign reads or writes proceed
+- Control-scoped MCP and agent updates now refuse silent remaps like `cm-04.02` to a different control when the exact control does not resolve in the active framework
+
+### Added
+- `pretorin_get_cli_status` and the `status://cli` MCP resource expose local CLI version, update availability, and upgrade guidance to MCP hosts and agents
+
+---
+
 ## [0.13.1] - 2026-04-07
 
 ### Added
@@ -234,6 +252,7 @@ All notable changes to the Pretorin CLI are documented here. The format is based
 - FedRAMP (Low, Moderate, High)
 - CMMC Level 1, 2, and 3
 
+[0.14.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/pretorin-ai/pretorin-cli/compare/v0.11.0...v0.12.0

--- a/pretorin-skill/SKILL.md
+++ b/pretorin-skill/SKILL.md
@@ -11,7 +11,7 @@ description: >
   "list frameworks", "show controls", "what documents do I need", "compliance check",
   "control requirements", "gap analysis", "audit my code", "run campaign",
   "vendor inheritance", "STIG rules", "CCI chain", and "scan compliance".
-version: 0.13.1
+version: 0.14.0
 ---
 
 # Pretorin Compliance Skill
@@ -54,6 +54,7 @@ Control and family IDs must be formatted correctly or the API will return errors
 - **800-171**: controls are dotted (`03.01.01`)
 
 When unsure of an ID, discover it first with `pretorin_list_control_families` or `pretorin_list_controls`.
+When the user already supplied a control ID and you have an active scope, try the exact control lookup in that active framework first. Do not silently remap the request to a different control or framework.
 
 ## Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pretorin"
-version = "0.13.1"
+version = "0.14.0"
 description = "CLI and MCP server for Pretorin Compliance API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pretorin/__init__.py
+++ b/src/pretorin/__init__.py
@@ -1,3 +1,3 @@
 """Pretorin CLI and MCP server for Pretorin Compliance API."""
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/src/pretorin/agent/skills.py
+++ b/src/pretorin/agent/skills.py
@@ -18,7 +18,11 @@ class Skill:
 
 _WORKFLOW_GUARDRAILS = (
     "Workflow requirements:\n"
+    "- Start from the active or provided execution scope first.\n"
     "- Read current platform state first (control context, current narrative, evidence, and notes).\n"
+    "- When the user supplies a control ID, resolve that exact control in the current "
+    "framework before any discovery calls.\n"
+    "- Do not silently remap a requested control to a different control or framework.\n"
     "- Use only observable facts from codebase and connected systems.\n"
     "- Do not hallucinate missing controls, integrations, or evidence.\n"
     "- Write auditor-ready markdown with no section headings.\n"

--- a/src/pretorin/agent/tools.py
+++ b/src/pretorin/agent/tools.py
@@ -76,20 +76,33 @@ def create_platform_tools(
     async def _resolve_scope(
         system_id: str | None = None,
         framework_id: str | None = None,
+        *,
+        enforce_active_context: bool = False,
+        allow_scope_override: bool = False,
     ) -> tuple[str, str]:
         return await resolve_execution_context(
             client,
             system=system_id,
             framework=framework_id,
             scope=scope,
+            enforce_active_context=enforce_active_context,
+            allow_scope_override=allow_scope_override,
         )
 
     async def _resolve_scoped_control(
         control_id: str,
         system_id: str | None = None,
         framework_id: str | None = None,
+        *,
+        enforce_active_context: bool = False,
+        allow_scope_override: bool = False,
     ) -> tuple[str, str, str]:
-        resolved_system_id, resolved_framework_id = await _resolve_scope(system_id, framework_id)
+        resolved_system_id, resolved_framework_id = await _resolve_scope(
+            system_id,
+            framework_id,
+            enforce_active_context=enforce_active_context,
+            allow_scope_override=allow_scope_override,
+        )
         normalized_control_id = _normalize(control_id) or control_id
         await client.get_control(resolved_framework_id, normalized_control_id)
         return resolved_system_id, resolved_framework_id, normalized_control_id
@@ -248,9 +261,15 @@ def create_platform_tools(
         control_id: str | None = None,
         framework_id: str | None = None,
         dedupe: bool = True,
+        allow_scope_override: bool = False,
     ) -> str:
         try:
-            resolved_system_id, resolved_framework_id = await _resolve_scope(system_id, framework_id)
+            resolved_system_id, resolved_framework_id = await _resolve_scope(
+                system_id,
+                framework_id,
+                enforce_active_context=True,
+                allow_scope_override=allow_scope_override,
+            )
             normalized_control_id = _normalize(control_id)
             if normalized_control_id:
                 await client.get_control(resolved_framework_id, normalized_control_id)
@@ -291,6 +310,11 @@ def create_platform_tools(
                     "control_id": {"type": "string", "description": "Associated control"},
                     "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
                     "dedupe": {"type": "boolean", "description": "Reuse exact-matching evidence", "default": True},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
                 "required": ["name", "description"],
             },
@@ -302,8 +326,14 @@ def create_platform_tools(
         items: list[dict[str, Any]],
         system_id: str | None = None,
         framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
-        resolved_system_id, resolved_framework_id = await _resolve_scope(system_id, framework_id)
+        resolved_system_id, resolved_framework_id = await _resolve_scope(
+            system_id,
+            framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
         payload_items = [
             EvidenceBatchItemCreate(
                 name=item["name"],
@@ -332,6 +362,11 @@ def create_platform_tools(
                 "properties": {
                     "system_id": {"type": "string", "description": "System ID (defaults to active scope)"},
                     "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                     "items": {
                         "type": "array",
                         "items": {
@@ -358,11 +393,14 @@ def create_platform_tools(
         control_id: str,
         system_id: str | None = None,
         framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
         resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
             control_id,
             system_id,
             framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
         )
         result = await client.link_evidence_to_control(
             evidence_id=evidence_id,
@@ -383,6 +421,11 @@ def create_platform_tools(
                     "evidence_id": {"type": "string", "description": "Evidence item ID"},
                     "control_id": {"type": "string", "description": "Control ID"},
                     "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
                 "required": ["evidence_id", "control_id"],
             },
@@ -393,11 +436,19 @@ def create_platform_tools(
     # --- Narratives ---
 
     async def get_narrative(
-        system_id: str,
         control_id: str,
-        framework_id: str,
+        system_id: str | None = None,
+        framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
-        narrative = await client.get_narrative(system_id, _normalize(control_id) or control_id, framework_id)
+        resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
+            control_id,
+            system_id,
+            framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
+        narrative = await client.get_narrative(resolved_system_id, normalized_control_id, resolved_framework_id)
         return json.dumps(narrative.model_dump(), default=str)
 
     tools.append(
@@ -407,27 +458,40 @@ def create_platform_tools(
             parameters={
                 "type": "object",
                 "properties": {
-                    "system_id": {"type": "string", "description": "System ID"},
+                    "system_id": {"type": "string", "description": "System ID (defaults to active scope)"},
                     "control_id": {"type": "string", "description": "Control ID"},
-                    "framework_id": {"type": "string", "description": "Framework ID (required)"},
+                    "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow reads/writes outside the active system/framework context",
+                        "default": False,
+                    },
                 },
-                "required": ["system_id", "control_id", "framework_id"],
+                "required": ["control_id"],
             },
             handler=get_narrative,
         )
     )
 
     async def add_control_note(
-        system_id: str,
         control_id: str,
-        framework_id: str,
         content: str,
+        system_id: str | None = None,
+        framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
+        resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
+            control_id,
+            system_id,
+            framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
         result = await client.add_control_note(
-            system_id=system_id,
-            control_id=_normalize(control_id) or control_id,
+            system_id=resolved_system_id,
+            control_id=normalized_control_id,
             content=content,
-            framework_id=framework_id,
+            framework_id=resolved_framework_id,
             source="cli",
         )
         return json.dumps(result, default=str)
@@ -439,12 +503,17 @@ def create_platform_tools(
             parameters={
                 "type": "object",
                 "properties": {
-                    "system_id": {"type": "string", "description": "System ID"},
+                    "system_id": {"type": "string", "description": "System ID (defaults to active scope)"},
                     "control_id": {"type": "string", "description": "Control ID"},
-                    "framework_id": {"type": "string", "description": "Framework ID"},
+                    "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
                     "content": {"type": "string", "description": "Note content"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
-                "required": ["system_id", "control_id", "framework_id", "content"],
+                "required": ["control_id", "content"],
             },
             handler=add_control_note,
         )
@@ -500,10 +569,16 @@ def create_platform_tools(
         event_type: str = "security_scan",
         control_id: str | None = None,
         description: str = "",
+        allow_scope_override: bool = False,
     ) -> str:
         from pretorin.client.models import MonitoringEventCreate
 
-        resolved_system_id, resolved_framework_id = await _resolve_scope(system_id, framework_id)
+        resolved_system_id, resolved_framework_id = await _resolve_scope(
+            system_id,
+            framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
         normalized_control_id = _normalize(control_id)
         if normalized_control_id:
             await client.get_control(resolved_framework_id, normalized_control_id)
@@ -533,6 +608,11 @@ def create_platform_tools(
                     "event_type": {"type": "string", "description": "Event type"},
                     "control_id": {"type": "string", "description": "Associated control"},
                     "description": {"type": "string", "description": "Event description"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
                 "required": ["title"],
             },
@@ -547,11 +627,14 @@ def create_platform_tools(
         status: str,
         system_id: str | None = None,
         framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
         resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
             control_id,
             system_id,
             framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
         )
         result = await client.update_control_status(
             resolved_system_id,
@@ -572,6 +655,11 @@ def create_platform_tools(
                     "control_id": {"type": "string", "description": "Control ID"},
                     "status": {"type": "string", "description": "New status"},
                     "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
                 "required": ["control_id", "status"],
             },
@@ -580,14 +668,22 @@ def create_platform_tools(
     )
 
     async def get_control_implementation(
-        system_id: str,
         control_id: str,
-        framework_id: str,
+        system_id: str | None = None,
+        framework_id: str | None = None,
+        allow_scope_override: bool = False,
     ) -> str:
-        impl = await client.get_control_implementation(
+        resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
+            control_id,
             system_id,
-            _normalize(control_id) or control_id,
             framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
+        impl = await client.get_control_implementation(
+            resolved_system_id,
+            normalized_control_id,
+            resolved_framework_id,
         )
         return json.dumps(impl.model_dump(), default=str)
 
@@ -598,11 +694,16 @@ def create_platform_tools(
             parameters={
                 "type": "object",
                 "properties": {
-                    "system_id": {"type": "string", "description": "System ID"},
+                    "system_id": {"type": "string", "description": "System ID (defaults to active scope)"},
                     "control_id": {"type": "string", "description": "Control ID"},
-                    "framework_id": {"type": "string", "description": "Framework ID (required)"},
+                    "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow reads/writes outside the active system/framework context",
+                        "default": False,
+                    },
                 },
-                "required": ["system_id", "control_id", "framework_id"],
+                "required": ["control_id"],
             },
             handler=get_control_implementation,
         )
@@ -670,18 +771,26 @@ def create_platform_tools(
     # --- Update Narrative ---
 
     async def update_narrative(
-        system_id: str,
         control_id: str,
-        framework_id: str,
         narrative: str,
+        system_id: str | None = None,
+        framework_id: str | None = None,
         is_ai_generated: bool = False,
+        allow_scope_override: bool = False,
     ) -> str:
+        resolved_system_id, resolved_framework_id, normalized_control_id = await _resolve_scoped_control(
+            control_id,
+            system_id,
+            framework_id,
+            enforce_active_context=True,
+            allow_scope_override=allow_scope_override,
+        )
         try:
             result = await client.update_narrative(
-                system_id,
-                _normalize(control_id) or control_id,
+                resolved_system_id,
+                normalized_control_id,
                 narrative,
-                framework_id,
+                resolved_framework_id,
                 is_ai_generated,
             )
         except ValueError as e:
@@ -695,9 +804,9 @@ def create_platform_tools(
             parameters={
                 "type": "object",
                 "properties": {
-                    "system_id": {"type": "string", "description": "System ID"},
+                    "system_id": {"type": "string", "description": "System ID (defaults to active scope)"},
                     "control_id": {"type": "string", "description": "Control ID"},
-                    "framework_id": {"type": "string", "description": "Framework ID"},
+                    "framework_id": {"type": "string", "description": "Framework ID (defaults to active scope)"},
                     "narrative": {
                         "type": "string",
                         "description": (
@@ -706,8 +815,13 @@ def create_platform_tools(
                         ),
                     },
                     "is_ai_generated": {"type": "boolean", "description": "AI-generated flag"},
+                    "allow_scope_override": {
+                        "type": "boolean",
+                        "description": "Allow writing outside the active system/framework context",
+                        "default": False,
+                    },
                 },
-                "required": ["system_id", "control_id", "framework_id", "narrative"],
+                "required": ["control_id", "narrative"],
             },
             handler=update_narrative,
         )

--- a/src/pretorin/cli/context.py
+++ b/src/pretorin/cli/context.py
@@ -162,7 +162,14 @@ async def resolve_execution_context(
         return scope.system_id, scope.framework_id
 
     from pretorin.client.api import PretorianClientError
+    from pretorin.client.config import Config
     from pretorin.workflows.compliance_updates import resolve_system
+
+    # When falling back to stored config, verify the environment hasn't changed.
+    if system is None and framework is None:
+        env_error = Config().check_context_environment()
+        if env_error:
+            raise PretorianClientError(env_error)
 
     system_value, framework_value = _resolve_context_values(system=system, framework=framework)
     if not system_value or not framework_value:
@@ -452,6 +459,7 @@ async def _context_set(
         config.set("active_system_id", system_id)
         config.set("active_system_name", system_name)
         config.set("active_framework_id", target_framework_id)
+        config.context_api_base_url = config.platform_api_base_url
 
         if is_json_mode():
             print_json(
@@ -518,6 +526,22 @@ async def _context_show(*, quiet: bool = False, check: bool = False) -> None:
         else:
             rprint(f"\n  {ROMEBOT_SAD}  No active context set.\n")
             rprint("  Run [bold]pretorin context set[/bold] to select a system and framework.")
+        if check:
+            raise typer.Exit(1)
+        return
+
+    # Check for environment mismatch before hitting the API.
+    env_error = config.check_context_environment()
+    if env_error:
+        payload = _build_context_payload(
+            system_id=system_id,
+            framework_id=framework_id,
+            system_name=cached_system_name,
+            valid=False,
+            validation_state="invalid",
+            validation_error=env_error,
+        )
+        _show_context_payload(payload, quiet=quiet)
         if check:
             raise typer.Exit(1)
         return
@@ -609,6 +633,7 @@ def context_clear() -> None:
     config.delete("active_system_id")
     config.delete("active_system_name")
     config.delete("active_framework_id")
+    config.delete("context_api_base_url")
 
     if is_json_mode():
         print_json({"cleared": True})

--- a/src/pretorin/cli/context.py
+++ b/src/pretorin/cli/context.py
@@ -227,15 +227,20 @@ async def resolve_execution_context(
         active_framework_id = config.active_framework_id
         if active_system_id and active_framework_id:
             if system_id != active_system_id or framework_id != active_framework_id:
+                active_scope_label = _format_scope_label(
+                    system_id=active_system_id,
+                    framework_id=active_framework_id,
+                    system_name=config.active_system_name,
+                )
+                requested_scope_label = _format_scope_label(
+                    system_id=system_id,
+                    framework_id=framework_id,
+                )
                 raise PretorianClientError(
                     "Active context is "
-                    f"'{_format_scope_label(
-                        system_id=active_system_id,
-                        framework_id=active_framework_id,
-                        system_name=config.active_system_name,
-                    )}'; "
+                    f"'{active_scope_label}'; "
                     "refusing write to "
-                    f"'{_format_scope_label(system_id=system_id, framework_id=framework_id)}' "
+                    f"'{requested_scope_label}' "
                     "without explicit scope override."
                 )
     return system_id, framework_id

--- a/src/pretorin/cli/context.py
+++ b/src/pretorin/cli/context.py
@@ -93,6 +93,19 @@ def _format_context_subject(payload: dict[str, Any]) -> str:
     return system_name or system_id or "-"
 
 
+def _format_scope_label(
+    *,
+    system_id: str | None,
+    framework_id: str | None,
+    system_name: str | None = None,
+) -> str:
+    """Return a compact scope label for guardrail messages."""
+    subject = system_name or system_id or "-"
+    if system_id and system_name and system_name != system_id:
+        subject = f"{system_name} ({system_id})"
+    return f"{subject} / {framework_id or '-'}"
+
+
 def _format_quiet_context(payload: dict[str, Any]) -> str:
     """Render a single-line context summary."""
     subject = _format_context_subject(payload)
@@ -150,6 +163,8 @@ async def resolve_execution_context(
     system: str | None = None,
     framework: str | None = None,
     scope: ExecutionScope | None = None,
+    enforce_active_context: bool = False,
+    allow_scope_override: bool = False,
 ) -> tuple[str, str]:
     """Resolve and validate a single execution scope against the platform.
 
@@ -165,9 +180,11 @@ async def resolve_execution_context(
     from pretorin.client.config import Config
     from pretorin.workflows.compliance_updates import resolve_system
 
+    config = Config()
+
     # When falling back to stored config, verify the environment hasn't changed.
     if system is None and framework is None:
-        env_error = Config().check_context_environment()
+        env_error = config.check_context_environment()
         if env_error:
             raise PretorianClientError(env_error)
 
@@ -193,6 +210,34 @@ async def resolve_execution_context(
             f"Framework '{framework_id}' is not associated with system '{system_id}'. "
             f"Available frameworks: {', '.join(sorted(available_frameworks))}"
         )
+
+    if enforce_active_context and not allow_scope_override:
+        if scope is not None:
+            if system_id != scope.system_id or framework_id != scope.framework_id:
+                raise PretorianClientError(
+                    "Execution scope is "
+                    f"'{_format_scope_label(system_id=scope.system_id, framework_id=scope.framework_id)}'; "
+                    "refusing write to "
+                    f"'{_format_scope_label(system_id=system_id, framework_id=framework_id)}' "
+                    "without explicit scope override."
+                )
+            return system_id, framework_id
+
+        active_system_id = config.active_system_id
+        active_framework_id = config.active_framework_id
+        if active_system_id and active_framework_id:
+            if system_id != active_system_id or framework_id != active_framework_id:
+                raise PretorianClientError(
+                    "Active context is "
+                    f"'{_format_scope_label(
+                        system_id=active_system_id,
+                        framework_id=active_framework_id,
+                        system_name=config.active_system_name,
+                    )}'; "
+                    "refusing write to "
+                    f"'{_format_scope_label(system_id=system_id, framework_id=framework_id)}' "
+                    "without explicit scope override."
+                )
     return system_id, framework_id
 
 

--- a/src/pretorin/cli/version_check.py
+++ b/src/pretorin/cli/version_check.py
@@ -19,6 +19,7 @@ FAILURE_CACHE_TTL_SECONDS = 3600  # 1 hour
 REQUEST_TIMEOUT_SECONDS = 1.0
 
 PYPI_URL = "https://pypi.org/pypi/pretorin/json"
+UPGRADE_COMMAND = "pip install --upgrade pretorin"
 
 
 @dataclass(frozen=True)
@@ -149,16 +150,51 @@ def check_for_updates(*, force: bool = False) -> VersionCheckResult:
     )
 
 
+def get_update_status(*, force: bool = False) -> dict[str, Any]:
+    """Return structured CLI update status for CLI and MCP surfaces."""
+    notifications_enabled = update_notifications_enabled()
+    status: dict[str, Any] = {
+        "current_version": __version__,
+        "latest_version": None,
+        "update_available": False,
+        "checked": False,
+        "notifications_enabled": notifications_enabled,
+        "upgrade_command": UPGRADE_COMMAND,
+        "message": "Passive update notifications are disabled.",
+        "prompt": None,
+    }
+
+    if not notifications_enabled:
+        return status
+
+    result = check_for_updates(force=force)
+    status["latest_version"] = result.latest_version
+    status["update_available"] = result.update_available
+    status["checked"] = result.checked
+
+    if result.update_available and result.latest_version:
+        prompt = (
+            f"A newer version of Pretorin CLI is available ({result.latest_version}). "
+            f"Run: {UPGRADE_COMMAND}"
+        )
+        status["message"] = prompt
+        status["prompt"] = prompt
+    elif result.checked:
+        status["message"] = "Pretorin CLI is up to date."
+    else:
+        status["message"] = "Unable to check for updates right now."
+
+    return status
+
+
 def get_update_message() -> str | None:
     """Get a formatted update message if an update is available."""
-    if not update_notifications_enabled():
-        return None
-
-    result = check_for_updates()
-    if result.update_available and result.latest_version:
+    status = get_update_status()
+    latest_version = status.get("latest_version")
+    if status.get("update_available") and latest_version:
         return (
             f"[#FF9010]→[/#FF9010] A newer version of Pretorin CLI is available "
-            f"([#EAB536]{result.latest_version}[/#EAB536])\n"
-            f"  [dim]Run:[/dim] [bold]pip install --upgrade pretorin[/bold]"
+            f"([#EAB536]{latest_version}[/#EAB536])\n"
+            f"  [dim]Run:[/dim] [bold]{UPGRADE_COMMAND}[/bold]"
         )
     return None

--- a/src/pretorin/cli/version_check.py
+++ b/src/pretorin/cli/version_check.py
@@ -173,10 +173,7 @@ def get_update_status(*, force: bool = False) -> dict[str, Any]:
     status["checked"] = result.checked
 
     if result.update_available and result.latest_version:
-        prompt = (
-            f"A newer version of Pretorin CLI is available ({result.latest_version}). "
-            f"Run: {UPGRADE_COMMAND}"
-        )
+        prompt = f"A newer version of Pretorin CLI is available ({result.latest_version}). Run: {UPGRADE_COMMAND}"
         status["message"] = prompt
         status["prompt"] = prompt
     elif result.checked:

--- a/src/pretorin/client/api.py
+++ b/src/pretorin/client/api.py
@@ -115,6 +115,11 @@ class PretorianClient:
         self._client: httpx.AsyncClient | None = None
 
     @property
+    def api_base_url(self) -> str:
+        """The resolved API base URL this client is targeting."""
+        return self._api_base_url
+
+    @property
     def is_configured(self) -> bool:
         """Check if the client has an API key configured."""
         return self._api_key is not None

--- a/src/pretorin/client/config.py
+++ b/src/pretorin/client/config.py
@@ -165,6 +165,37 @@ class Config:
         self.set("model_api_base_url", value)
 
     @property
+    def context_api_base_url(self) -> str | None:
+        """Get the API base URL that was active when the context was set."""
+        return self.get("context_api_base_url")
+
+    @context_api_base_url.setter
+    def context_api_base_url(self, value: str | None) -> None:
+        """Set the API base URL captured at context-set time."""
+        if value is None:
+            self.delete("context_api_base_url")
+        else:
+            self.set("context_api_base_url", value)
+
+    def check_context_environment(self) -> str | None:
+        """Compare stored context URL against the current platform URL.
+
+        Returns ``None`` when the environment matches (or when no stored URL
+        exists for backward compatibility).  Returns a human-readable error
+        string when the URLs diverge.
+        """
+        stored = self.context_api_base_url
+        if not stored:
+            return None
+        current = self.platform_api_base_url
+        if stored.rstrip("/") == current.rstrip("/"):
+            return None
+        return (
+            f"Context was set against '{stored}' but the current API environment is "
+            f"'{current}'. Run 'pretorin context set' to update your context."
+        )
+
+    @property
     def active_system_id(self) -> str | None:
         """Get the active system ID for context commands."""
         return self.get("active_system_id")
@@ -175,6 +206,7 @@ class Config:
         if value is None:
             self.delete("active_system_id")
             self.delete("active_system_name")
+            self.delete("context_api_base_url")
         else:
             self.set("active_system_id", value)
 

--- a/src/pretorin/mcp/handlers/__init__.py
+++ b/src/pretorin/mcp/handlers/__init__.py
@@ -55,6 +55,7 @@ from pretorin.mcp.handlers.stig import (
     handle_submit_test_results,
 )
 from pretorin.mcp.handlers.systems import (
+    handle_get_cli_status,
     handle_get_compliance_status,
     handle_get_system,
     handle_list_systems,
@@ -117,6 +118,7 @@ TOOL_HANDLERS: dict[str, ToolHandler] = {
     "pretorin_get_control_references": handle_get_control_references,
     "pretorin_get_document_requirements": handle_get_document_requirements,
     "pretorin_list_systems": handle_list_systems,
+    "pretorin_get_cli_status": handle_get_cli_status,
     "pretorin_get_system": handle_get_system,
     "pretorin_get_compliance_status": handle_get_compliance_status,
     "pretorin_search_evidence": handle_search_evidence,

--- a/src/pretorin/mcp/handlers/compliance.py
+++ b/src/pretorin/mcp/handlers/compliance.py
@@ -21,7 +21,6 @@ from pretorin.mcp.helpers import (
     resolve_system_id,
     validate_enum,
 )
-from pretorin.utils import normalize_control_id
 from pretorin.workflows.ai_generation import draft_control_artifacts
 
 logger = logging.getLogger(__name__)
@@ -74,7 +73,11 @@ async def handle_push_monitoring_event(
     if enum_err:
         return format_error(enum_err)
 
-    system_id, framework_id, normalized_control_id = await resolve_execution_scope(client, arguments)
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        enforce_active_context=True,
+    )
     event = MonitoringEventCreate(
         event_type=event_type,
         title=arguments["title"],
@@ -204,18 +207,21 @@ async def handle_add_control_note(
 ) -> list[TextContent] | CallToolResult:
     """Handle the add_control_note tool."""
     logger.debug("handle_add_control_note called with %s", _safe_args(arguments))
-    err = require(arguments, "system_id", "control_id", "framework_id", "content")
+    err = require(arguments, "control_id", "content")
     if err:
         return format_error(err)
 
-    system_id = await resolve_system_id(client, arguments)
-    if system_id is None:
-        raise PretorianClientError("system_id is required")
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        control_required=True,
+        enforce_active_context=True,
+    )
     result = await client.add_control_note(
         system_id=system_id,
-        control_id=normalize_control_id(arguments["control_id"]),
+        control_id=normalized_control_id or "",
         content=arguments["content"],
-        framework_id=arguments["framework_id"],
+        framework_id=framework_id,
         source="cli",
     )
     return format_json(result)
@@ -254,18 +260,21 @@ async def handle_update_narrative(
 ) -> list[TextContent] | CallToolResult:
     """Handle the update_narrative tool."""
     logger.debug("handle_update_narrative called with %s", _safe_args(arguments))
-    err = require(arguments, "system_id", "control_id", "framework_id", "narrative")
+    err = require(arguments, "control_id", "narrative")
     if err:
         return format_error(err)
 
-    system_id = await resolve_system_id(client, arguments)
-    if system_id is None:
-        raise PretorianClientError("system_id is required")
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        control_required=True,
+        enforce_active_context=True,
+    )
     try:
         result = await client.update_narrative(
             system_id=system_id,
-            control_id=normalize_control_id(arguments["control_id"]),
-            framework_id=arguments["framework_id"],
+            control_id=normalized_control_id or "",
+            framework_id=framework_id,
             narrative=arguments["narrative"],
             is_ai_generated=arguments.get("is_ai_generated", False),
         )
@@ -292,6 +301,7 @@ async def handle_update_control_status(
         client,
         arguments,
         control_required=True,
+        enforce_active_context=True,
     )
     result = await client.update_control_status(
         system_id=system_id,
@@ -308,17 +318,20 @@ async def handle_get_control_implementation(
 ) -> list[TextContent] | CallToolResult:
     """Handle the get_control_implementation tool."""
     logger.debug("handle_get_control_implementation called with %s", _safe_args(arguments))
-    err = require(arguments, "system_id", "control_id", "framework_id")
+    err = require(arguments, "control_id")
     if err:
         return format_error(err)
 
-    system_id = await resolve_system_id(client, arguments)
-    if system_id is None:
-        raise PretorianClientError("system_id is required")
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        control_required=True,
+        enforce_active_context=True,
+    )
     impl = await client.get_control_implementation(
         system_id=system_id,
-        control_id=normalize_control_id(arguments["control_id"]),
-        framework_id=arguments["framework_id"],
+        control_id=normalized_control_id or "",
+        framework_id=framework_id,
     )
     return format_json(
         {

--- a/src/pretorin/mcp/handlers/evidence.py
+++ b/src/pretorin/mcp/handlers/evidence.py
@@ -8,7 +8,6 @@ from typing import Any
 from mcp.types import CallToolResult, TextContent
 
 from pretorin.client import PretorianClient
-from pretorin.client.api import PretorianClientError
 from pretorin.client.models import EvidenceBatchItemCreate
 from pretorin.mcp.helpers import (
     VALID_EVIDENCE_TYPES,
@@ -16,7 +15,6 @@ from pretorin.mcp.helpers import (
     format_json,
     require,
     resolve_execution_scope,
-    resolve_system_id,
     validate_enum,
 )
 from pretorin.utils import normalize_control_id
@@ -79,7 +77,11 @@ async def handle_create_evidence(
         return format_error(enum_err)
 
     dedupe = arguments.get("dedupe", True)
-    system_id, framework_id, normalized_control_id = await resolve_execution_scope(client, arguments)
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        enforce_active_context=True,
+    )
     try:
         result = await upsert_evidence(
             client,
@@ -109,7 +111,11 @@ async def handle_create_evidence_batch(
     if err:
         return format_error(err)
 
-    system_id, framework_id, _ = await resolve_execution_scope(client, arguments)
+    system_id, framework_id, _ = await resolve_execution_scope(
+        client,
+        arguments,
+        enforce_active_context=True,
+    )
     items = arguments.get("items", [])
     payload_items = []
     for item in items:
@@ -145,6 +151,7 @@ async def handle_link_evidence(
         client,
         arguments,
         control_required=True,
+        enforce_active_context=True,
     )
     result = await client.link_evidence_to_control(
         evidence_id=arguments["evidence_id"],
@@ -161,17 +168,20 @@ async def handle_get_narrative(
 ) -> list[TextContent] | CallToolResult:
     """Handle the get_narrative tool."""
     logger.debug("handle_get_narrative called with %s", _safe_args(arguments))
-    err = require(arguments, "system_id", "control_id", "framework_id")
+    err = require(arguments, "control_id")
     if err:
         return format_error(err)
 
-    system_id = await resolve_system_id(client, arguments)
-    if system_id is None:
-        raise PretorianClientError("system_id is required")
+    system_id, framework_id, normalized_control_id = await resolve_execution_scope(
+        client,
+        arguments,
+        control_required=True,
+        enforce_active_context=True,
+    )
     narrative = await client.get_narrative(
         system_id=system_id,
-        control_id=normalize_control_id(arguments["control_id"]),
-        framework_id=arguments["framework_id"],
+        control_id=normalized_control_id or "",
+        framework_id=framework_id,
     )
     return format_json(
         {

--- a/src/pretorin/mcp/handlers/systems.py
+++ b/src/pretorin/mcp/handlers/systems.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from mcp.types import TextContent
 
+from pretorin.cli.version_check import get_update_status
 from pretorin.client import PretorianClient
 from pretorin.client.api import PretorianClientError
 from pretorin.mcp.helpers import format_json, resolve_system_id
@@ -81,3 +82,12 @@ async def handle_get_compliance_status(
         raise PretorianClientError("system_id is required")
     status = await client.get_system_compliance_status(system_id)
     return format_json(status)
+
+
+async def handle_get_cli_status(
+    _client: PretorianClient | None,
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    """Handle the get_cli_status tool."""
+    logger.debug("handle_get_cli_status called with %s", _safe_args(arguments))
+    return format_json(get_update_status(force=bool(arguments.get("force", False))))

--- a/src/pretorin/mcp/helpers.py
+++ b/src/pretorin/mcp/helpers.py
@@ -86,8 +86,7 @@ def allow_scope_override_property() -> dict[str, Any]:
     return {
         "type": "boolean",
         "description": (
-            "Allow writes outside the active system/framework context. "
-            "Defaults to false and should be used sparingly."
+            "Allow writes outside the active system/framework context. Defaults to false and should be used sparingly."
         ),
         "default": False,
     }

--- a/src/pretorin/mcp/helpers.py
+++ b/src/pretorin/mcp/helpers.py
@@ -81,6 +81,18 @@ def system_id_property(*, optional: bool = False) -> dict[str, Any]:
     }
 
 
+def allow_scope_override_property() -> dict[str, Any]:
+    """Return a shared JSON schema field for explicit scope overrides."""
+    return {
+        "type": "boolean",
+        "description": (
+            "Allow writes outside the active system/framework context. "
+            "Defaults to false and should be used sparingly."
+        ),
+        "default": False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Response formatters
 # ---------------------------------------------------------------------------
@@ -152,6 +164,7 @@ async def resolve_execution_scope(
     *,
     scope: ExecutionScope | None = None,
     control_required: bool = False,
+    enforce_active_context: bool = False,
 ) -> tuple[str, str, str | None]:
     """Resolve one validated execution scope and optionally validate a control within it."""
     system_id, framework_id = await resolve_execution_context(
@@ -159,6 +172,8 @@ async def resolve_execution_scope(
         system=arguments.get("system_id"),
         framework=arguments.get("framework_id"),
         scope=scope,
+        enforce_active_context=enforce_active_context,
+        allow_scope_override=bool(arguments.get("allow_scope_override", False)),
     )
     raw_control_id = arguments.get("control_id")
     normalized_control_id = normalize_control_id(raw_control_id) if raw_control_id else None

--- a/src/pretorin/mcp/resources.py
+++ b/src/pretorin/mcp/resources.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from mcp.types import Resource
 
+from pretorin.cli.version_check import get_update_status
 from pretorin.mcp.prompts import (
     format_control_analysis_prompt,
     get_artifact_schema,
@@ -33,6 +34,12 @@ async def list_resources() -> list[Resource]:
             uri="analysis://schema",
             name="Compliance Artifact Schema",
             description="JSON schema for compliance artifacts that AI should produce during analysis",
+            mimeType="text/markdown",
+        ),
+        Resource(
+            uri="status://cli",
+            name="Pretorin CLI Status",
+            description="Current CLI version, update availability, and upgrade guidance for MCP hosts and agents",
             mimeType="text/markdown",
         ),
     ]
@@ -76,6 +83,30 @@ async def list_resources() -> list[Resource]:
 async def read_resource(uri: str) -> str:
     """Read an analysis resource."""
     parsed = urlparse(uri)
+
+    if parsed.scheme == "status":
+        if parsed.netloc != "cli":
+            raise ValueError(f"Unknown status resource: {parsed.netloc}")
+
+        status = get_update_status()
+        latest_version = status["latest_version"] or "unknown"
+        update_available = "yes" if status["update_available"] else "no"
+        notifications_enabled = "yes" if status["notifications_enabled"] else "no"
+        check_state = "verified" if status["checked"] else "unverified"
+
+        lines = [
+            "# Pretorin CLI Status",
+            "",
+            f"- Current version: `{status['current_version']}`",
+            f"- Latest version: `{latest_version}`",
+            f"- Update available: `{update_available}`",
+            f"- Passive notifications enabled: `{notifications_enabled}`",
+            f"- Check state: `{check_state}`",
+            f"- Upgrade command: `{status['upgrade_command']}`",
+            "",
+            status["message"],
+        ]
+        return "\n".join(lines)
 
     if parsed.scheme == "workflow":
         resource_type = parsed.netloc

--- a/src/pretorin/mcp/server.py
+++ b/src/pretorin/mcp/server.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import CallToolResult, Resource, TextContent, Tool
 
+from pretorin.cli.version_check import get_update_status
 from pretorin.client import PretorianClient
 from pretorin.client.api import AuthenticationError, NotFoundError, PretorianClientError
 from pretorin.mcp.handlers import TOOL_HANDLERS
@@ -19,6 +21,7 @@ from pretorin.mcp.resources import read_resource as _read_resource
 from pretorin.mcp.tools import list_tools as _list_tools
 
 logger = logging.getLogger(__name__)
+PUBLIC_TOOL_NAMES = {"pretorin_get_cli_status"}
 
 # Create the MCP server instance
 server = Server(
@@ -31,7 +34,9 @@ server = Server(
         "or MCP. Without a system, platform write features (evidence, narratives, "
         "monitoring, control status) cannot be used. If list_systems returns no "
         "systems, tell the user they need a beta code to create one on the platform "
-        "and can sign up for early access at https://pretorin.com/early-access/."
+        "and can sign up for early access at https://pretorin.com/early-access/. "
+        "MCP hosts can inspect pretorin_get_cli_status or status://cli to surface "
+        "local CLI update guidance."
     ),
 )
 
@@ -59,12 +64,18 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent] |
     """Handle tool calls."""
     logger.info("Tool call: %s", name)
     try:
+        handler = TOOL_HANDLERS.get(name)
+        if name in PUBLIC_TOOL_NAMES:
+            if handler:
+                return await handler(None, arguments)
+            logger.warning("Unknown tool requested: %s", name)
+            return format_error(f"Unknown tool: {name}")
+
         async with PretorianClient() as client:
             if not client.is_configured:
                 logger.warning("Tool call %s failed: client not authenticated", name)
                 return format_error("Not authenticated. Please run 'pretorin login' in the terminal first.")
 
-            handler = TOOL_HANDLERS.get(name)
             if handler:
                 return await handler(client, arguments)
             else:
@@ -95,9 +106,19 @@ async def _run_server() -> None:
         )
 
 
+def _maybe_print_startup_update_notice() -> None:
+    """Emit a non-blocking update prompt for MCP hosts on stderr."""
+    status = get_update_status()
+    prompt = status.get("prompt")
+    if not prompt:
+        return
+    print(f"NOTICE: {prompt}", file=sys.stderr, flush=True)
+
+
 def run_server() -> None:
     """Entry point to run the MCP server."""
     logger.info("Starting Pretorin MCP server")
+    _maybe_print_startup_update_notice()
     asyncio.run(_run_server())
 
 

--- a/src/pretorin/mcp/tools.py
+++ b/src/pretorin/mcp/tools.py
@@ -9,6 +9,7 @@ from pretorin.mcp.helpers import (
     VALID_EVENT_TYPES,
     VALID_EVIDENCE_TYPES,
     VALID_SEVERITIES,
+    allow_scope_override_property,
     control_id_property,
     system_id_property,
 )
@@ -157,6 +158,24 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="pretorin_get_cli_status",
+            description=(
+                "Return the local Pretorin CLI version status, including update availability "
+                "and upgrade guidance for MCP hosts and agents"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "force": {
+                        "type": "boolean",
+                        "description": "Bypass the local cache and re-check PyPI for the latest version",
+                        "default": False,
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
             name="pretorin_get_system",
             description=(
                 "Get detailed information about a specific system including frameworks and security impact level"
@@ -239,6 +258,7 @@ async def list_tools() -> list[Tool]:
                         "description": "Whether to reuse exact-matching org evidence before creating",
                         "default": True,
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
                 "required": ["name", "description"],
             },
@@ -272,6 +292,7 @@ async def list_tools() -> list[Tool]:
                             "required": ["name", "description", "control_id"],
                         },
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
                 "required": ["items"],
             },
@@ -292,6 +313,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Optional: Framework context for the link; defaults to active scope",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
                 "required": ["evidence_id", "control_id"],
             },
@@ -303,14 +325,15 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": system_id_property(),
+                    "system_id": system_id_property(optional=True),
                     "control_id": control_id_property(),
                     "framework_id": {
                         "type": "string",
-                        "description": "The framework ID (required for narrative lookup)",
+                        "description": "Optional: Framework ID; defaults to active scope",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
-                "required": ["system_id", "control_id", "framework_id"],
+                "required": ["control_id"],
             },
         ),
         Tool(
@@ -373,6 +396,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Optional: Detailed event description",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
                 "required": ["title"],
             },
@@ -516,11 +540,11 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": system_id_property(),
+                    "system_id": system_id_property(optional=True),
                     "control_id": control_id_property(),
                     "framework_id": {
                         "type": "string",
-                        "description": "The framework ID",
+                        "description": "Optional: Framework ID; defaults to active scope",
                     },
                     "narrative": {
                         "type": "string",
@@ -534,8 +558,9 @@ async def list_tools() -> list[Tool]:
                         "description": "Whether the narrative was AI-generated",
                         "default": False,
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
-                "required": ["system_id", "control_id", "framework_id", "narrative"],
+                "required": ["control_id", "narrative"],
             },
         ),
         Tool(
@@ -548,18 +573,19 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": system_id_property(),
+                    "system_id": system_id_property(optional=True),
                     "control_id": control_id_property(),
                     "framework_id": {
                         "type": "string",
-                        "description": "The framework ID",
+                        "description": "Optional: Framework ID; defaults to active scope",
                     },
                     "content": {
                         "type": "string",
                         "description": "Note content (suggestions, manual steps, integration guidance)",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
-                "required": ["system_id", "control_id", "framework_id", "content"],
+                "required": ["control_id", "content"],
             },
         ),
         Tool(
@@ -598,6 +624,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "description": "Optional: Framework ID; defaults to active scope",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
                 "required": ["control_id", "status"],
             },
@@ -610,14 +637,15 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "system_id": system_id_property(),
+                    "system_id": system_id_property(optional=True),
                     "control_id": control_id_property(),
                     "framework_id": {
                         "type": "string",
-                        "description": "The framework ID (required for control lookup)",
+                        "description": "Optional: Framework ID; defaults to active scope",
                     },
+                    "allow_scope_override": allow_scope_override_property(),
                 },
-                "required": ["system_id", "control_id", "framework_id"],
+                "required": ["control_id"],
             },
         ),
         # === Agentic Workflow Tools ===

--- a/src/pretorin/workflows/campaign.py
+++ b/src/pretorin/workflows/campaign.py
@@ -669,6 +669,7 @@ def build_campaign_summary(
     *,
     output_mode: str | None = None,
     prepared_only: bool = False,
+    apply_override: bool | None = None,
 ) -> CampaignRunSummary:
     """Build a campaign summary from a checkpoint."""
     counts = _status_counts(checkpoint)
@@ -677,7 +678,7 @@ def build_campaign_summary(
     return CampaignRunSummary(
         domain=str(checkpoint.identity.get("domain", request.domain)),
         mode=str(checkpoint.identity.get("mode", request.mode)),
-        apply=bool(checkpoint.identity.get("apply", request.apply)),
+        apply=apply_override if apply_override is not None else bool(checkpoint.identity.get("apply", request.apply)),
         output_mode=output_mode or checkpoint.output,
         checkpoint_path=str(checkpoint_path),
         workflow_snapshot=checkpoint.workflow_snapshot,
@@ -1423,7 +1424,10 @@ async def apply_campaign(
             _record_event(checkpoint, presenter, "item_failed", str(exc), item=item)
         _write_checkpoint(checkpoint_path, checkpoint)
 
-    return build_campaign_summary(checkpoint, checkpoint_path, output_mode=request.output)
+    checkpoint.identity["apply"] = True
+    _write_checkpoint(checkpoint_path, checkpoint)
+
+    return build_campaign_summary(checkpoint, checkpoint_path, output_mode=request.output, apply_override=True)
 
 
 def _mark_item_failed(

--- a/src/pretorin/workflows/campaign.py
+++ b/src/pretorin/workflows/campaign.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import logging
 import sys
 from collections import deque
 from collections.abc import Awaitable, Callable
@@ -26,6 +27,8 @@ from pretorin.client.api import PretorianClientError
 from pretorin.client.models import EvidenceBatchItemCreate, OrgPolicyQuestionnaireResponse, ScopeResponse
 from pretorin.scope import ExecutionScope
 from pretorin.utils import normalize_control_id
+
+logger = logging.getLogger(__name__)
 
 ROMEBOT_COLOR = "#EAB536"
 OUTPUT_AUTO = "auto"
@@ -91,6 +94,7 @@ class WorkflowContextSnapshot:
     analytics_summary: dict[str, Any] = field(default_factory=dict)
     family_analytics: dict[str, Any] = field(default_factory=dict)
     extras: dict[str, Any] = field(default_factory=dict)
+    platform_api_base_url: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return _safe_json_dict(asdict(self))
@@ -572,6 +576,24 @@ def _validate_checkpoint_identity(checkpoint: CampaignCheckpoint, request: Campa
         )
 
 
+def _validate_checkpoint_environment(client: PretorianClient, snapshot: WorkflowContextSnapshot) -> None:
+    """Verify the checkpoint's API environment matches the current client."""
+    checkpoint_url = snapshot.platform_api_base_url
+    if not checkpoint_url:
+        logger.warning(
+            "Campaign checkpoint does not include platform_api_base_url; "
+            "cannot verify environment affinity. Consider re-preparing."
+        )
+        return
+    current_url = client.api_base_url
+    if checkpoint_url.rstrip("/") != current_url.rstrip("/"):
+        raise PretorianClientError(
+            f"This checkpoint was prepared against '{checkpoint_url}' but the current "
+            f"API environment is '{current_url}'. Re-prepare the campaign against the "
+            f"correct environment."
+        )
+
+
 def _lease_expired(item_state: CampaignItemState) -> bool:
     if item_state.lease_expires_at is None:
         return False
@@ -895,6 +917,7 @@ async def _prepare_controls_context(
         analytics_summary=analytics_summary,
         family_analytics=family_analytics,
         extras=extras,
+        platform_api_base_url=client.api_base_url,
     )
     return snapshot, items
 
@@ -931,6 +954,7 @@ async def _prepare_policy_context(
         subject=f"{len(items)} policy workflow(s)",
         workflow_state={"policy_ids": [policy.id for policy in selected]},
         extras=extras,
+        platform_api_base_url=client.api_base_url,
     )
     return snapshot, items
 
@@ -955,6 +979,7 @@ async def _prepare_scope_context(
         scope={"system_id": system_id, "framework_id": framework_id},
         workflow_state=workflow_state,
         extras={"scope": scope.model_dump(mode="json")},
+        platform_api_base_url=client.api_base_url,
     )
     items = [
         CampaignItem(
@@ -1011,6 +1036,10 @@ async def prepare_campaign(
         _validate_checkpoint_identity(checkpoint, request)
         checkpoint.output = request.output
         checkpoint.request = request.to_dict()
+        # Backfill platform_api_base_url for legacy checkpoints.
+        ws = checkpoint.workflow_snapshot
+        if not ws.get("platform_api_base_url"):
+            ws["platform_api_base_url"] = client.api_base_url
         _record_event(checkpoint, presenter, "run_attached", "Attached to existing checkpoint")
         _write_checkpoint(request.checkpoint_path, checkpoint)
 
@@ -1231,6 +1260,7 @@ async def get_campaign_item_context(
     checkpoint = _load_checkpoint(checkpoint_path)
     if checkpoint is None:
         raise PretorianClientError(f"Campaign checkpoint not found: {checkpoint_path}")
+    _validate_checkpoint_environment(client, WorkflowContextSnapshot(**checkpoint.workflow_snapshot))
     item_state = checkpoint.items.get(item_id)
     if item_state is None:
         raise PretorianClientError(f"Campaign item not found: {item_id}")
@@ -1387,6 +1417,7 @@ async def apply_campaign(
         raise PretorianClientError(f"Campaign checkpoint not found: {checkpoint_path}")
     request = _request_from_checkpoint(checkpoint_path, checkpoint)
     snapshot = WorkflowContextSnapshot(**checkpoint.workflow_snapshot)
+    _validate_checkpoint_environment(client, snapshot)
     selected = set(item_ids or [])
 
     for item_id, item_state in checkpoint.items.items():

--- a/tests/test_agent_tools_coverage.py
+++ b/tests/test_agent_tools_coverage.py
@@ -10,7 +10,6 @@ import pytest
 
 from pretorin.agent.tools import ToolDefinition, create_platform_tools, to_function_tool
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -48,7 +47,9 @@ def mock_client() -> AsyncMock:
     client = AsyncMock()
     client.list_systems = AsyncMock(return_value=[{"id": "sys-1", "name": "System 1"}])
     client.get_system = AsyncMock(return_value=_ModelStub({"id": "sys-1", "name": "System 1"}))
-    client.get_system_compliance_status = AsyncMock(return_value={"status": "partial"})
+    client.get_system_compliance_status = AsyncMock(
+        return_value={"status": "partial", "frameworks": [{"framework_id": "fw-1"}]}
+    )
     client.list_frameworks = AsyncMock(return_value=_ModelStub({"frameworks": []}))
     client.get_control = AsyncMock(return_value=_ModelStub({"id": "ac-02", "title": "Account Mgmt"}))
     client.get_controls_batch = AsyncMock(return_value=_ModelStub({"controls": [], "total": 0}))
@@ -74,6 +75,19 @@ def mock_client() -> AsyncMock:
     )
     client.update_narrative = AsyncMock(return_value={"ok": True})
     return client
+
+
+@pytest.fixture(autouse=True)
+def _blank_active_context() -> None:
+    """Keep agent tool tests independent from the developer's local config."""
+    config = MagicMock()
+    config.check_context_environment.return_value = None
+    config.active_system_id = None
+    config.active_framework_id = None
+    config.active_system_name = None
+    config.get.side_effect = lambda _key, default=None: default
+    with patch("pretorin.client.config.Config", return_value=config):
+        yield
 
 
 def _build_tools_patched(mock_client: AsyncMock) -> tuple[list[ToolDefinition], AsyncMock]:

--- a/tests/test_campaign_cli.py
+++ b/tests/test_campaign_cli.py
@@ -478,6 +478,9 @@ async def test_prepare_claim_submit_apply_policy_campaign(tmp_path: Path) -> Non
     summary = await apply_campaign(client, request.checkpoint_path)
 
     assert summary.succeeded == 1
+    assert summary.apply is True
+    status = get_campaign_status(request.checkpoint_path)
+    assert status.apply is True
     client.patch_org_policy_qa.assert_awaited_once_with(
         "pol-001",
         [{"question_id": "q_scope_2", "answer": "Production systems, CUI, administrators, and service accounts."}],

--- a/tests/test_campaign_cli.py
+++ b/tests/test_campaign_cli.py
@@ -50,6 +50,7 @@ def _reset_json_mode() -> None:
 def _mock_campaign_client() -> AsyncMock:
     client = AsyncMock()
     client.is_configured = True
+    client.api_base_url = "https://platform.pretorin.com/api/v1/public"
     return client
 
 
@@ -578,6 +579,80 @@ def test_submit_campaign_proposal_rejects_invalid_questionnaire_shape(tmp_path: 
 
     with pytest.raises(PretorianClientError, match="questions list"):
         submit_campaign_proposal(path, item_id="pol-001", proposal={"summary": "missing questions"})
+
+
+@pytest.mark.asyncio
+async def test_apply_campaign_rejects_checkpoint_with_wrong_environment(tmp_path: Path) -> None:
+    """apply_campaign should raise when checkpoint URL differs from client URL."""
+    client = _mock_campaign_client()
+    client.api_base_url = "https://platform.pretorin.com/api/v1/public"
+
+    checkpoint = CampaignCheckpoint(
+        version=2,
+        identity={"domain": "policy", "mode": "answer", "apply": False},
+        request={
+            "domain": "policy",
+            "mode": "answer",
+            "apply": False,
+            "output": "json",
+            "concurrency": 1,
+            "max_retries": 1,
+            "working_directory": str(tmp_path),
+        },
+        output="json",
+        created_at="2026-04-02T00:00:00+00:00",
+        updated_at="2026-04-02T00:00:00+00:00",
+        workflow_snapshot={
+            "domain": "policy",
+            "subject": "Policies",
+            "platform_api_base_url": "https://localhost:8000/api/v1/public",
+        },
+        items={"pol-001": CampaignItemState(item={"item_id": "pol-001", "label": "Policy", "kind": "policy"})},
+        events=[],
+    )
+    path = tmp_path / "campaign.json"
+    path.write_text(json.dumps(checkpoint.to_dict()))
+
+    with pytest.raises(PretorianClientError, match="prepared against"):
+        await apply_campaign(client, path)
+
+
+@pytest.mark.asyncio
+async def test_apply_campaign_warns_for_legacy_checkpoint_without_url(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Legacy checkpoints without platform_api_base_url should log a warning but not raise."""
+    client = _mock_campaign_client()
+    client.api_base_url = "https://platform.pretorin.com/api/v1/public"
+
+    # Checkpoint with no items to apply — just verify the warning fires and no error is raised.
+    checkpoint = CampaignCheckpoint(
+        version=2,
+        identity={"domain": "policy", "mode": "answer", "apply": False},
+        request={
+            "domain": "policy",
+            "mode": "answer",
+            "apply": False,
+            "output": "json",
+            "concurrency": 1,
+            "max_retries": 1,
+            "working_directory": str(tmp_path),
+        },
+        output="json",
+        created_at="2026-04-02T00:00:00+00:00",
+        updated_at="2026-04-02T00:00:00+00:00",
+        workflow_snapshot={"domain": "policy", "subject": "Policies"},
+        items={},
+        events=[],
+    )
+    path = tmp_path / "campaign.json"
+    path.write_text(json.dumps(checkpoint.to_dict()))
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="pretorin.workflows.campaign"):
+        summary = await apply_campaign(client, path)
+
+    assert "cannot verify environment affinity" in caplog.text
+    assert summary.total == 0
 
 
 def test_get_campaign_status_includes_snapshot(tmp_path: Path) -> None:

--- a/tests/test_cli_context_coverage.py
+++ b/tests/test_cli_context_coverage.py
@@ -186,6 +186,7 @@ def test_context_show_with_context_set_json_mode():
         ]}
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",

--- a/tests/test_cli_context_coverage2.py
+++ b/tests/test_cli_context_coverage2.py
@@ -100,6 +100,7 @@ def test_ensure_single_framework_scope_returns_empty_for_whitespace_only():
 async def test_resolve_execution_context_raises_when_no_system():
     """Line 67: raises PretorianClientError when system_value is missing."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.return_value = None
     client = AsyncMock()
 
@@ -111,6 +112,7 @@ async def test_resolve_execution_context_raises_when_no_system():
 async def test_resolve_execution_context_raises_when_no_framework():
     """Line 67: raises PretorianClientError when framework_value is missing."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": None,
@@ -125,6 +127,7 @@ async def test_resolve_execution_context_raises_when_no_framework():
 async def test_resolve_execution_context_rejects_multi_framework():
     """Lines 72-74: raises PretorianClientError when framework contains separators."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fw1,fw2",
@@ -139,6 +142,7 @@ async def test_resolve_execution_context_rejects_multi_framework():
 async def test_resolve_execution_context_no_frameworks_on_system():
     """Lines 78-81: raises PretorianClientError when system has no frameworks."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -156,6 +160,7 @@ async def test_resolve_execution_context_no_frameworks_on_system():
 async def test_resolve_execution_context_framework_not_available():
     """Lines 82-86: raises PretorianClientError when requested framework not on system."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-high",
@@ -175,6 +180,7 @@ async def test_resolve_execution_context_framework_not_available():
 async def test_resolve_execution_context_success():
     """Lines 75-87: successful resolution returns (system_id, framework_id)."""
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -470,6 +476,7 @@ def test_context_show_no_context_json_mode():
     """Lines 390-391: JSON mode outputs null values when no context set."""
     client = _make_client()
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.return_value = None
     with patch("pretorin.client.config.Config", return_value=mock_config):
         result = _run_with_mock_client(["--json", "context", "show"], client)
@@ -484,6 +491,7 @@ def test_context_show_no_context_normal_mode():
     """Lines 392-395: non-JSON mode prints sad message when no context."""
     client = _make_client()
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.return_value = None
     with patch("pretorin.client.config.Config", return_value=mock_config):
         result = _run_with_mock_client(["context", "show"], client)
@@ -500,6 +508,7 @@ def test_context_show_not_configured_non_json():
     """Line 403: renders a Panel with stored context when not logged in (non-JSON)."""
     client = _make_client(configured=False)
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-offline",
         "active_system_name": "Offline System",
@@ -527,6 +536,7 @@ def test_context_show_marks_missing_system_as_invalid():
         ]}
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-unknown-id",
         "active_system_name": "Retired System",
@@ -554,6 +564,7 @@ def test_context_show_compliance_status_error_keeps_defaults():
         side_effect=PretorianClientError("compliance error")
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -576,6 +587,7 @@ def test_context_show_marks_missing_framework_as_invalid():
         compliance_status={"frameworks": [{"framework_id": "fedramp-low", "progress": 10, "status": "in_progress"}]},
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -603,6 +615,7 @@ def test_context_show_non_json_with_live_data():
         ]}
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -620,6 +633,7 @@ def test_context_show_non_json_system_error_and_compliance_error():
         side_effect=PretorianClientError("compliance error")
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -638,6 +652,7 @@ def test_context_show_quiet_outputs_single_line():
         compliance_status={"frameworks": [{"framework_id": "fedramp-moderate", "progress": 80, "status": "implemented"}]},
     )
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-1",
         "active_framework_id": "fedramp-moderate",
@@ -652,6 +667,7 @@ def test_context_show_check_exits_nonzero_for_stale_context():
     """Check mode should fail fast when stored context points at a missing system."""
     client = _make_client(systems=[{"id": "sys-1", "name": "Primary"}])
     mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
     mock_config.get.side_effect = lambda key, *a: {
         "active_system_id": "sys-missing",
         "active_system_name": "Retired System",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,3 +115,75 @@ def test_api_base_url_alias_setter_updates_platform_key(
     assert cfg_reloaded.api_base_url == "https://alias.custom.example/v1"
     assert cfg_reloaded.platform_api_base_url == "https://alias.custom.example/v1"
     assert cfg_reloaded.get("platform_api_base_url") == "https://alias.custom.example/v1"
+
+
+# --- Environment-aware context validation ---
+
+
+def test_check_context_environment_detects_mismatch(
+    monkeypatch: MonkeyPatch,
+    isolated_config_paths: Path,
+) -> None:
+    monkeypatch.delenv(config_module.ENV_PLATFORM_API_BASE_URL, raising=False)
+    monkeypatch.delenv(config_module.ENV_API_BASE_URL, raising=False)
+
+    cfg = config_module.Config()
+    cfg.context_api_base_url = "https://localhost:8000/api/v1/public"
+    # Current platform URL defaults to DEFAULT_PLATFORM_API_BASE_URL (prod)
+    error = cfg.check_context_environment()
+    assert error is not None
+    assert "localhost:8000" in error
+    assert config_module.DEFAULT_PLATFORM_API_BASE_URL in error
+
+
+def test_check_context_environment_ok_when_matching(
+    monkeypatch: MonkeyPatch,
+    isolated_config_paths: Path,
+) -> None:
+    monkeypatch.delenv(config_module.ENV_PLATFORM_API_BASE_URL, raising=False)
+    monkeypatch.delenv(config_module.ENV_API_BASE_URL, raising=False)
+
+    cfg = config_module.Config()
+    cfg.context_api_base_url = config_module.DEFAULT_PLATFORM_API_BASE_URL
+    assert cfg.check_context_environment() is None
+
+
+def test_check_context_environment_normalizes_trailing_slash(
+    monkeypatch: MonkeyPatch,
+    isolated_config_paths: Path,
+) -> None:
+    monkeypatch.delenv(config_module.ENV_PLATFORM_API_BASE_URL, raising=False)
+    monkeypatch.delenv(config_module.ENV_API_BASE_URL, raising=False)
+
+    cfg = config_module.Config()
+    cfg.context_api_base_url = config_module.DEFAULT_PLATFORM_API_BASE_URL + "/"
+    assert cfg.check_context_environment() is None
+
+
+def test_check_context_environment_skips_when_no_stored_url(
+    monkeypatch: MonkeyPatch,
+    isolated_config_paths: Path,
+) -> None:
+    monkeypatch.delenv(config_module.ENV_PLATFORM_API_BASE_URL, raising=False)
+    monkeypatch.delenv(config_module.ENV_API_BASE_URL, raising=False)
+
+    cfg = config_module.Config()
+    # No context_api_base_url set — backward compat
+    assert cfg.check_context_environment() is None
+
+
+def test_clearing_active_system_also_clears_context_url(
+    monkeypatch: MonkeyPatch,
+    isolated_config_paths: Path,
+) -> None:
+    monkeypatch.delenv(config_module.ENV_PLATFORM_API_BASE_URL, raising=False)
+    monkeypatch.delenv(config_module.ENV_API_BASE_URL, raising=False)
+
+    cfg = config_module.Config()
+    cfg.set("active_system_id", "sys-1")
+    cfg.context_api_base_url = "https://localhost:8000/api/v1/public"
+    assert cfg.context_api_base_url is not None
+
+    cfg.active_system_id = None
+    cfg_reloaded = config_module.Config()
+    assert cfg_reloaded.context_api_base_url is None

--- a/tests/test_context_scope.py
+++ b/tests/test_context_scope.py
@@ -80,8 +80,6 @@ async def test_resolve_execution_context_rejects_stale_environment() -> None:
 @pytest.mark.asyncio
 async def test_resolve_execution_context_skips_env_check_with_explicit_args() -> None:
     """When explicit system/framework are passed, environment check should not fire."""
-    from pretorin.client import config as config_module
-
     client = AsyncMock()
     client.list_systems = AsyncMock(return_value=[{"id": "sys-1", "name": "Test System"}])
     client.get_system_compliance_status = AsyncMock(
@@ -96,3 +94,70 @@ async def test_resolve_execution_context_skips_env_check_with_explicit_args() ->
     )
     assert system_id == "sys-1"
     assert framework_id == "fedramp-moderate"
+
+
+@pytest.mark.asyncio
+async def test_resolve_execution_context_rejects_mismatched_write_scope() -> None:
+    """Strict write resolution should refuse scopes outside the active context by default."""
+    from unittest.mock import MagicMock, patch
+
+    mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
+    mock_config.active_system_id = "sys-1"
+    mock_config.active_framework_id = "fedramp-moderate"
+    mock_config.active_system_name = "System One"
+
+    client = AsyncMock()
+    client.list_systems = AsyncMock(
+        return_value=[
+            {"id": "sys-1", "name": "System One"},
+            {"id": "sys-2", "name": "System Two"},
+        ]
+    )
+    client.get_system_compliance_status = AsyncMock(
+        return_value={"frameworks": [{"framework_id": "fedramp-high"}, {"framework_id": "fedramp-moderate"}]}
+    )
+
+    with patch("pretorin.client.config.Config", return_value=mock_config):
+        with pytest.raises(PretorianClientError, match="Active context is"):
+            await resolve_execution_context(
+                client,
+                system="sys-2",
+                framework="fedramp-high",
+                enforce_active_context=True,
+            )
+
+
+@pytest.mark.asyncio
+async def test_resolve_execution_context_allows_explicit_scope_override() -> None:
+    """Explicit scope override should bypass the active-context write guardrail."""
+    from unittest.mock import MagicMock, patch
+
+    mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = None
+    mock_config.active_system_id = "sys-1"
+    mock_config.active_framework_id = "fedramp-moderate"
+    mock_config.active_system_name = "System One"
+
+    client = AsyncMock()
+    client.list_systems = AsyncMock(
+        return_value=[
+            {"id": "sys-1", "name": "System One"},
+            {"id": "sys-2", "name": "System Two"},
+        ]
+    )
+    client.get_system_compliance_status = AsyncMock(
+        return_value={"frameworks": [{"framework_id": "fedramp-high"}, {"framework_id": "fedramp-moderate"}]}
+    )
+
+    with patch("pretorin.client.config.Config", return_value=mock_config):
+        system_id, framework_id = await resolve_execution_context(
+            client,
+            system="sys-2",
+            framework="fedramp-high",
+            enforce_active_context=True,
+            allow_scope_override=True,
+        )
+
+    assert system_id == "sys-2"
+    assert framework_id == "fedramp-high"

--- a/tests/test_context_scope.py
+++ b/tests/test_context_scope.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -58,31 +57,24 @@ async def test_resolve_execution_context_rejects_wrong_framework_for_system() ->
 
 
 @pytest.mark.asyncio
-async def test_resolve_execution_context_rejects_stale_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolve_execution_context_rejects_stale_environment() -> None:
     """When both system and framework fall back to stored config, environment mismatch should be caught."""
-    from pretorin.client import config as config_module
+    from unittest.mock import MagicMock, patch
 
-    monkeypatch.delenv("PRETORIN_PLATFORM_API_BASE_URL", raising=False)
-    monkeypatch.delenv("PRETORIN_API_BASE_URL", raising=False)
+    mock_config = MagicMock()
+    mock_config.check_context_environment.return_value = (
+        "Context was set against 'https://localhost:8000' but the current API environment is "
+        "'https://platform.pretorin.com'. Run 'pretorin context set' to update your context."
+    )
+    mock_config.get.side_effect = lambda key, *a: {
+        "active_system_id": "sys-1",
+        "active_framework_id": "fedramp-moderate",
+    }.get(key)
 
-    config_dir = Path(__file__).parent / "_tmp_ctx_env"
-    config_file = config_dir / "config.json"
-    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
-
-    try:
-        cfg = config_module.Config()
-        cfg.set("active_system_id", "sys-1")
-        cfg.set("active_framework_id", "fedramp-moderate")
-        cfg.context_api_base_url = "https://localhost:8000/api/v1/public"
-
-        client = AsyncMock()
+    client = AsyncMock()
+    with patch("pretorin.client.config.Config", return_value=mock_config):
         with pytest.raises(PretorianClientError, match="Context was set against"):
             await resolve_execution_context(client)
-    finally:
-        import shutil
-
-        shutil.rmtree(config_dir, ignore_errors=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_context_scope.py
+++ b/tests/test_context_scope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -54,3 +55,52 @@ async def test_resolve_execution_context_rejects_wrong_framework_for_system() ->
             system="sys-1",
             framework="fedramp-high",
         )
+
+
+@pytest.mark.asyncio
+async def test_resolve_execution_context_rejects_stale_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When both system and framework fall back to stored config, environment mismatch should be caught."""
+    from pretorin.client import config as config_module
+
+    monkeypatch.delenv("PRETORIN_PLATFORM_API_BASE_URL", raising=False)
+    monkeypatch.delenv("PRETORIN_API_BASE_URL", raising=False)
+
+    config_dir = Path(__file__).parent / "_tmp_ctx_env"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", config_file)
+
+    try:
+        cfg = config_module.Config()
+        cfg.set("active_system_id", "sys-1")
+        cfg.set("active_framework_id", "fedramp-moderate")
+        cfg.context_api_base_url = "https://localhost:8000/api/v1/public"
+
+        client = AsyncMock()
+        with pytest.raises(PretorianClientError, match="Context was set against"):
+            await resolve_execution_context(client)
+    finally:
+        import shutil
+
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_execution_context_skips_env_check_with_explicit_args() -> None:
+    """When explicit system/framework are passed, environment check should not fire."""
+    from pretorin.client import config as config_module
+
+    client = AsyncMock()
+    client.list_systems = AsyncMock(return_value=[{"id": "sys-1", "name": "Test System"}])
+    client.get_system_compliance_status = AsyncMock(
+        return_value={"frameworks": [{"framework_id": "fedramp-moderate"}]}
+    )
+
+    # Even if stored context URL is stale, explicit args should bypass the check.
+    system_id, framework_id = await resolve_execution_context(
+        client,
+        system="sys-1",
+        framework="fedramp-moderate",
+    )
+    assert system_id == "sys-1"
+    assert framework_id == "fedramp-moderate"

--- a/tests/test_control_id_normalization.py
+++ b/tests/test_control_id_normalization.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -16,6 +16,19 @@ from pretorin.client.models import (
     ImplementationStatement,
 )
 from pretorin.utils import normalize_control_id
+
+
+@pytest.fixture(autouse=True)
+def _blank_active_context() -> None:
+    """Keep control-id tests independent from the developer's local config."""
+    config = MagicMock()
+    config.check_context_environment.return_value = None
+    config.active_system_id = None
+    config.active_framework_id = None
+    config.active_system_name = None
+    config.get.side_effect = lambda _key, default=None: default
+    with patch("pretorin.client.config.Config", return_value=config):
+        yield
 
 
 @pytest.mark.asyncio
@@ -135,15 +148,20 @@ async def test_agent_tool_search_evidence_normalizes_control_id_filter() -> None
 @pytest.mark.asyncio
 async def test_agent_tool_add_control_note_normalizes_control_id() -> None:
     mock_client = AsyncMock()
+    mock_client.get_control = AsyncMock(return_value=AsyncMock())
     mock_client.add_control_note = AsyncMock(return_value={"ok": True})
 
-    tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
-    await tools["add_control_note"].handler(
-        system_id="sys-1",
-        control_id="ac-2",
-        framework_id="fedramp-moderate",
-        content="Need manual SSO upload",
-    )
+    with patch(
+        "pretorin.agent.tools.resolve_execution_context",
+        new=AsyncMock(return_value=("sys-1", "fedramp-moderate")),
+    ):
+        tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
+        await tools["add_control_note"].handler(
+            system_id="sys-1",
+            control_id="ac-2",
+            framework_id="fedramp-moderate",
+            content="Need manual SSO upload",
+        )
 
     mock_client.add_control_note.assert_awaited_once_with(
         system_id="sys-1",
@@ -226,7 +244,7 @@ def test_normalize_passes_cmmc_and_800_171_ids_unchanged(raw: str, expected: str
 
 
 # =========================================================================
-# get_control_implementation requires framework_id
+# get_control_implementation uses exact scoped control lookup
 # =========================================================================
 
 
@@ -259,18 +277,20 @@ async def test_client_get_narrative_uses_scoped_endpoint() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_get_control_implementation_requires_framework_id() -> None:
+async def test_agent_tool_get_control_implementation_uses_scoped_lookup() -> None:
     mock_client = AsyncMock()
+    mock_client.get_control = AsyncMock(return_value=AsyncMock())
     mock_client.get_control_implementation = AsyncMock(
         return_value=AsyncMock(model_dump=lambda: {"control_id": "ac.l1-3.1.1"})
     )
 
-    tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
-    await tools["get_control_implementation"].handler(
-        system_id="sys-1",
-        control_id="AC.L1-3.1.1",
-        framework_id="cmmc-l1",
-    )
+    with patch("pretorin.agent.tools.resolve_execution_context", new=AsyncMock(return_value=("sys-1", "cmmc-l1"))):
+        tools = {tool.name: tool for tool in create_platform_tools(mock_client)}
+        await tools["get_control_implementation"].handler(
+            system_id="sys-1",
+            control_id="AC.L1-3.1.1",
+            framework_id="cmmc-l1",
+        )
 
     mock_client.get_control_implementation.assert_awaited_once_with(
         "sys-1",

--- a/tests/test_mcp_compliance_coverage.py
+++ b/tests/test_mcp_compliance_coverage.py
@@ -8,9 +8,9 @@ handle_update_control_status, handle_get_control_implementation.
 
 from __future__ import annotations
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from mcp.types import CallToolResult
 
 from pretorin.client.api import PretorianClientError
@@ -19,14 +19,11 @@ from pretorin.mcp.handlers.compliance import (
     handle_generate_control_artifacts,
     handle_get_control_context,
     handle_get_control_implementation,
-    handle_get_control_notes,
     handle_get_scope,
     handle_push_monitoring_event,
     handle_update_control_status,
     handle_update_narrative,
 )
-from pretorin.mcp.helpers import format_error
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -244,7 +241,10 @@ class TestHandleGetScope:
     async def test_success_returns_scope(self):
         from pretorin.client.models import ScopeResponse
 
-        scope = ScopeResponse(scope_status="complete", scope_narrative={"description": "In scope: all production systems."})
+        scope = ScopeResponse(
+            scope_status="complete",
+            scope_narrative={"description": "In scope: all production systems."},
+        )
         client = _make_client(get_scope=scope)
         with patch(
             "pretorin.mcp.handlers.compliance.resolve_system_id",
@@ -300,8 +300,8 @@ class TestHandleAddControlNote:
         note_response = {"id": "note-1", "content": "Manual review complete", "source": "cli"}
         client = _make_client(add_control_note=note_response)
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value="sys-1"),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate", "ac-02")),
         ):
             result = await handle_add_control_note(
                 client,
@@ -344,8 +344,8 @@ class TestHandleUpdateNarrative:
         narrative_response = {"control_id": "ac-02", "narrative": "Access is controlled via RBAC."}
         client = _make_client(update_narrative=narrative_response)
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value="sys-1"),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate", "ac-02")),
         ):
             result = await handle_update_narrative(
                 client,
@@ -364,8 +364,8 @@ class TestHandleUpdateNarrative:
         client = _make_client()
         client.update_narrative = AsyncMock(side_effect=ValueError("narrative too long"))
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value="sys-1"),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate", "ac-02")),
         ):
             result = await handle_update_narrative(
                 client,
@@ -449,13 +449,25 @@ class TestHandleGetControlImplementation:
         assert "Missing required" in _error_text(result)
 
     @pytest.mark.asyncio
-    async def test_missing_framework_id_returns_error(self):
-        client = _make_client()
-        result = await handle_get_control_implementation(
-            client, {"system_id": "sys-1", "control_id": "ac-02"}
+    async def test_uses_active_scope_when_explicit_scope_omitted(self):
+        from pretorin.client.models import ControlImplementationResponse
+
+        client = _make_client(
+            get_control_implementation=ControlImplementationResponse(
+                control_id="ac-02",
+                status="partially_implemented",
+                implementation_narrative="In progress.",
+                evidence_count=2,
+                notes=[{"content": "Reviewing access logs"}],
+            )
         )
-        assert _is_error(result)
-        assert "framework_id" in _error_text(result)
+        with patch(
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate", "ac-02")),
+        ):
+            result = await handle_get_control_implementation(client, {"control_id": "ac-02"})
+        assert isinstance(result, list)
+        assert "ac-02" in _result_text(result)
 
     @pytest.mark.asyncio
     async def test_success_returns_implementation(self):
@@ -470,8 +482,8 @@ class TestHandleGetControlImplementation:
         )
         client = _make_client(get_control_implementation=impl)
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value="sys-1"),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate", "ac-02")),
         ):
             result = await handle_get_control_implementation(
                 client,

--- a/tests/test_mcp_compliance_coverage2.py
+++ b/tests/test_mcp_compliance_coverage2.py
@@ -1,8 +1,4 @@
-"""Additional coverage tests for src/pretorin/mcp/handlers/compliance.py.
-
-Covers line 144 (add_control_note system_id None), line 194 (update_narrative
-system_id None), line 248 (get_control_implementation system_id None).
-"""
+"""Additional coverage tests for src/pretorin/mcp/handlers/compliance.py."""
 
 from __future__ import annotations
 
@@ -28,15 +24,15 @@ def _make_client(**overrides) -> AsyncMock:
 
 
 class TestAddControlNoteSystemIdNone:
-    """Tests for handle_add_control_note when system_id is None."""
+    """Tests for handle_add_control_note when scope resolution fails."""
 
     @pytest.mark.asyncio
     async def test_system_id_none_raises(self):
-        """Line 144: system_id resolves to None raises PretorianClientError."""
+        """Scope resolution failure should surface as a client error."""
         client = _make_client()
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value=None),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(side_effect=PretorianClientError("system_id is required")),
         ):
             with pytest.raises(PretorianClientError, match="system_id is required"):
                 await handle_add_control_note(
@@ -51,15 +47,15 @@ class TestAddControlNoteSystemIdNone:
 
 
 class TestUpdateNarrativeSystemIdNone:
-    """Tests for handle_update_narrative when system_id is None."""
+    """Tests for handle_update_narrative when scope resolution fails."""
 
     @pytest.mark.asyncio
     async def test_system_id_none_raises(self):
-        """Line 194: system_id resolves to None raises PretorianClientError."""
+        """Scope resolution failure should surface as a client error."""
         client = _make_client()
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value=None),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(side_effect=PretorianClientError("system_id is required")),
         ):
             with pytest.raises(PretorianClientError, match="system_id is required"):
                 await handle_update_narrative(
@@ -74,15 +70,15 @@ class TestUpdateNarrativeSystemIdNone:
 
 
 class TestGetControlImplementationSystemIdNone:
-    """Tests for handle_get_control_implementation when system_id is None."""
+    """Tests for handle_get_control_implementation when scope resolution fails."""
 
     @pytest.mark.asyncio
     async def test_system_id_none_raises(self):
-        """Line 248: system_id resolves to None raises PretorianClientError."""
+        """Scope resolution failure should surface as a client error."""
         client = _make_client()
         with patch(
-            "pretorin.mcp.handlers.compliance.resolve_system_id",
-            new=AsyncMock(return_value=None),
+            "pretorin.mcp.handlers.compliance.resolve_execution_scope",
+            new=AsyncMock(side_effect=PretorianClientError("system_id is required")),
         ):
             with pytest.raises(PretorianClientError, match="system_id is required"):
                 await handle_get_control_implementation(

--- a/tests/test_mcp_evidence_coverage.py
+++ b/tests/test_mcp_evidence_coverage.py
@@ -19,7 +19,6 @@ from pretorin.mcp.handlers.evidence import (
     handle_create_evidence_batch,
     handle_get_narrative,
     handle_link_evidence,
-    handle_search_evidence,
 )
 
 
@@ -163,11 +162,11 @@ class TestHandleGetNarrative:
 
     @pytest.mark.asyncio
     async def test_client_error_in_get_narrative(self):
-        """Line 170: PretorianClientError raised when system_id is None."""
+        """Scope resolution failures should bubble up as PretorianClientError."""
         client = _make_client()
         with patch(
-            "pretorin.mcp.handlers.evidence.resolve_system_id",
-            new=AsyncMock(return_value=None),
+            "pretorin.mcp.handlers.evidence.resolve_execution_scope",
+            new=AsyncMock(side_effect=PretorianClientError("system_id is required")),
         ):
             with pytest.raises(PretorianClientError, match="system_id is required"):
                 await handle_get_narrative(

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,5 +1,7 @@
 """Tests for MCP resources."""
 
+from unittest.mock import patch
+
 import pytest
 
 from pretorin.mcp.server import list_resources, read_resource
@@ -26,6 +28,13 @@ class TestListResources:
         resources = await list_resources()
         uris = [str(r.uri) for r in resources]
         assert "analysis://schema" in uris
+
+    @pytest.mark.asyncio
+    async def test_list_resources_contains_cli_status(self):
+        """Test that CLI status resource is listed."""
+        resources = await list_resources()
+        uris = [str(r.uri) for r in resources]
+        assert "status://cli" in uris
 
     @pytest.mark.asyncio
     async def test_list_resources_contains_framework_guides(self):
@@ -94,6 +103,34 @@ class TestReadResourceSchema:
         content = await read_resource("analysis://schema")
         assert "json" in content.lower()
         assert "example" in content.lower() or "{" in content
+
+
+class TestReadResourceStatus:
+    """Tests for reading the CLI status resource."""
+
+    @pytest.mark.asyncio
+    async def test_read_cli_status_resource(self):
+        """Test reading the CLI status resource."""
+        with patch(
+            "pretorin.mcp.resources.get_update_status",
+            return_value={
+                "current_version": "0.14.0",
+                "latest_version": "0.15.0",
+                "update_available": True,
+                "checked": True,
+                "notifications_enabled": True,
+                "upgrade_command": "pip install --upgrade pretorin",
+                "message": "A newer version of Pretorin CLI is available (0.15.0). Run: pip install --upgrade pretorin",
+                "prompt": "A newer version of Pretorin CLI is available (0.15.0). Run: pip install --upgrade pretorin",
+            },
+        ):
+            content = await read_resource("status://cli")
+
+        assert isinstance(content, str)
+        assert "Pretorin CLI Status" in content
+        assert "`0.14.0`" in content
+        assert "`0.15.0`" in content
+        assert "pip install --upgrade pretorin" in content
 
 
 class TestReadResourceGuide:
@@ -219,6 +256,13 @@ class TestReadResourceErrors:
         with pytest.raises(ValueError) as exc_info:
             await read_resource("unknown://schema")
         assert "Unknown resource scheme" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_resource_raises_error(self):
+        """Test that unknown status resource raises error."""
+        with pytest.raises(ValueError) as exc_info:
+            await read_resource("status://unknown")
+        assert "Unknown status resource" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_unknown_resource_type_raises_error(self):

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -7,6 +7,7 @@ Covers lines 75-76 (AuthenticationError handler), 78-79 (NotFoundError handler),
 
 from __future__ import annotations
 
+from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -129,6 +130,23 @@ class TestRunServer:
             mock_run.assert_called_once()
             coroutine = mock_run.call_args.args[0]
             coroutine.close()
+
+    def test_run_server_prints_update_notice_to_stderr(self):
+        """Startup update notices should go to stderr, not stdout."""
+        from pretorin.mcp.server import run_server
+
+        stderr = StringIO()
+        with patch("pretorin.mcp.server.asyncio.run") as mock_run, \
+             patch(
+                 "pretorin.mcp.server.get_update_status",
+                 return_value={"prompt": "A newer version is available."},
+             ), \
+             patch("sys.stderr", stderr):
+            run_server()
+
+        assert "NOTICE: A newer version is available." in stderr.getvalue()
+        coroutine = mock_run.call_args.args[0]
+        coroutine.close()
 
 
 class TestMainGuard:

--- a/tests/test_mcp_tools_expanded.py
+++ b/tests/test_mcp_tools_expanded.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from pretorin.client.api import NotFoundError, PretorianClientError
 from pretorin.mcp.server import call_tool, list_tools
@@ -33,6 +35,7 @@ class TestToolListing:
             "pretorin_get_document_requirements",
             # System & compliance 3
             "pretorin_list_systems",
+            "pretorin_get_cli_status",
             "pretorin_get_system",
             "pretorin_get_compliance_status",
             # Evidence 4
@@ -82,7 +85,7 @@ class TestToolListing:
             "pretorin_infer_stigs",
         ]
 
-        assert len(tools) == 82
+        assert len(tools) == 83
         for name in expected:
             assert name in tool_names, f"Missing tool: {name}"
 
@@ -129,6 +132,19 @@ def _make_mock_client(**overrides: Any) -> AsyncMock:
     for attr, val in overrides.items():
         setattr(client, attr, AsyncMock(return_value=val))
     return client
+
+
+@pytest.fixture(autouse=True)
+def _blank_active_context() -> None:
+    """Keep MCP tool tests independent from the developer's local config."""
+    config = MagicMock()
+    config.check_context_environment.return_value = None
+    config.active_system_id = None
+    config.active_framework_id = None
+    config.active_system_name = None
+    config.get.side_effect = lambda _key, default=None: default
+    with patch("pretorin.client.config.Config", return_value=config):
+        yield
 
 
 def _run_tool(name: str, arguments: dict[str, Any], mock_client: AsyncMock) -> Any:
@@ -197,6 +213,27 @@ class TestSystemTools:
         result = _run_tool("pretorin_get_compliance_status", {"system_id": "sys-1"}, client)
         data = _parse_result(result)
         assert data["system_id"] == "sys-1"
+
+    def test_get_cli_status_without_authentication(self) -> None:
+        status_data = {
+            "current_version": "0.14.0",
+            "latest_version": "0.15.0",
+            "update_available": True,
+            "checked": True,
+            "notifications_enabled": True,
+            "upgrade_command": "pip install --upgrade pretorin",
+            "message": "A newer version of Pretorin CLI is available (0.15.0). Run: pip install --upgrade pretorin",
+            "prompt": "A newer version of Pretorin CLI is available (0.15.0). Run: pip install --upgrade pretorin",
+        }
+
+        with patch("pretorin.mcp.server.PretorianClient") as mock_client, \
+             patch("pretorin.mcp.handlers.systems.get_update_status", return_value=status_data):
+            result = asyncio.run(call_tool("pretorin_get_cli_status", {}))
+
+        mock_client.assert_not_called()
+        data = _parse_result(result)
+        assert data["update_available"] is True
+        assert data["latest_version"] == "0.15.0"
 
 
 class TestEvidenceTools:
@@ -431,11 +468,25 @@ class TestNarrativeTools:
             framework_id="fedramp-moderate",
         )
 
-    def test_get_narrative_missing_framework_id(self) -> None:
-        client = _make_mock_client()
-        result = _run_tool("pretorin_get_narrative", {"system_id": "sys-1", "control_id": "ac-2"}, client)
-        assert result.isError is True
-        assert any("Missing required" in c.text for c in result.content)
+    def test_get_narrative_uses_active_scope_when_explicit_scope_omitted(self) -> None:
+        from pretorin.client.models import NarrativeResponse
+
+        client = _make_mock_client(
+            get_narrative=NarrativeResponse(
+                control_id="ac-2",
+                framework_id="fedramp-moderate",
+                narrative="Existing narrative",
+                ai_confidence_score=0.9,
+                status="approved",
+            )
+        )
+        with patch(
+            "pretorin.mcp.helpers.resolve_execution_context",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate")),
+        ):
+            result = _run_tool("pretorin_get_narrative", {"control_id": "ac-2"}, client)
+        data = _parse_result(result)
+        assert data["control_id"] == "ac-2"
 
     def test_get_narrative_resolves_system_name(self) -> None:
         from pretorin.client.models import NarrativeResponse
@@ -728,15 +779,29 @@ class TestControlImplementationTools:
             framework_id="fedramp-moderate",
         )
 
-    def test_get_control_implementation_missing_framework_id(self) -> None:
-        client = _make_mock_client()
-        result = _run_tool(
-            "pretorin_get_control_implementation",
-            {"system_id": "sys-1", "control_id": "ac-2"},
-            client,
+    def test_get_control_implementation_uses_active_scope_when_explicit_scope_omitted(self) -> None:
+        from pretorin.client.models import ControlImplementationResponse
+
+        client = _make_mock_client(
+            get_control_implementation=ControlImplementationResponse(
+                control_id="ac-2",
+                status="partially_implemented",
+                implementation_narrative="In progress",
+                evidence_count=3,
+                notes=[{"content": "Working on it"}],
+            )
         )
-        assert result.isError is True
-        assert any("Missing required" in c.text for c in result.content)
+        with patch(
+            "pretorin.mcp.helpers.resolve_execution_context",
+            new=AsyncMock(return_value=("sys-1", "fedramp-moderate")),
+        ):
+            result = _run_tool(
+                "pretorin_get_control_implementation",
+                {"control_id": "ac-2"},
+                client,
+            )
+        data = _parse_result(result)
+        assert data["control_id"] == "ac-2"
 
 
 class TestErrorHandling:

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -91,3 +91,33 @@ def test_get_update_message_uses_cached_success(
 
     assert message is not None
     assert "9.9.9" in message
+
+
+def test_get_update_status_includes_prompt_when_update_available(
+    monkeypatch: MonkeyPatch,
+    isolated_update_paths: Path,
+) -> None:
+    monkeypatch.setattr(version_check, "_fetch_latest_version", lambda: "9.9.9")
+
+    status = version_check.get_update_status()
+
+    assert status["current_version"] == version_check.__version__
+    assert status["latest_version"] == "9.9.9"
+    assert status["update_available"] is True
+    assert status["checked"] is True
+    assert status["notifications_enabled"] is True
+    assert "pip install --upgrade pretorin" in status["prompt"]
+
+
+def test_get_update_status_respects_opt_out(
+    monkeypatch: MonkeyPatch,
+    isolated_update_paths: Path,
+) -> None:
+    monkeypatch.setenv(config_module.ENV_DISABLE_UPDATE_CHECK, "1")
+
+    status = version_check.get_update_status()
+
+    assert status["notifications_enabled"] is False
+    assert status["checked"] is False
+    assert status["update_available"] is False
+    assert status["prompt"] is None

--- a/tests/test_version_check_coverage.py
+++ b/tests/test_version_check_coverage.py
@@ -11,8 +11,6 @@ import json
 import time
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from pretorin.cli.version_check import (
     CACHE_TTL_SECONDS,
     FAILURE_CACHE_TTL_SECONDS,
@@ -22,6 +20,7 @@ from pretorin.cli.version_check import (
     _save_cache,
     check_for_updates,
     get_update_message,
+    get_update_status,
 )
 
 
@@ -224,3 +223,25 @@ class TestGetUpdateMessage:
         assert result is not None
         assert "99.0.0" in result
         assert "pip install --upgrade" in result
+
+
+class TestGetUpdateStatus:
+    """Tests for get_update_status."""
+
+    def test_get_update_status_disabled(self):
+        with patch("pretorin.cli.version_check.update_notifications_enabled", return_value=False):
+            result = get_update_status()
+        assert result["notifications_enabled"] is False
+        assert result["message"] == "Passive update notifications are disabled."
+
+    def test_get_update_status_up_to_date(self):
+        from pretorin.cli.version_check import VersionCheckResult
+
+        with patch("pretorin.cli.version_check.update_notifications_enabled", return_value=True), \
+             patch(
+                 "pretorin.cli.version_check.check_for_updates",
+                 return_value=VersionCheckResult(latest_version="0.14.0", update_available=False, checked=True),
+             ):
+            result = get_update_status()
+        assert result["checked"] is True
+        assert result["message"] == "Pretorin CLI is up to date."


### PR DESCRIPTION
## Summary
- merge the fixes from PR #59 and PR #61 into one release-ready branch
- implement issue #62 by enforcing active-scope writes by default with explicit override support
- add MCP-visible CLI update prompts via startup notice, `pretorin_get_cli_status`, and `status://cli`
- bump the package and skill version metadata to 0.14.0 and update changelogs

## Details
- strict scope enforcement now flows through shared execution-scope helpers for MCP and agent write paths
- exact control lookup now happens in the resolved framework before writes proceed, preventing silent remaps
- MCP startup emits a non-blocking stderr update notice when a newer CLI is available, and hosts can inspect update state through a public MCP tool/resource

## Verification
- `PYTHONPATH=src .venv/bin/pytest`
- `PYTHONPATH=src .venv/bin/pytest tests/test_version_check.py tests/test_version_check_coverage.py tests/test_mcp_server_coverage.py tests/test_mcp_resources.py tests/test_mcp_tools_expanded.py tests/test_cli_main_coverage.py`
- `PYTHONPATH=src .venv/bin/ruff check src/pretorin/cli/version_check.py src/pretorin/mcp/server.py src/pretorin/mcp/resources.py src/pretorin/mcp/tools.py src/pretorin/mcp/handlers/systems.py src/pretorin/mcp/handlers/__init__.py tests/test_version_check.py tests/test_version_check_coverage.py tests/test_mcp_server_coverage.py tests/test_mcp_resources.py tests/test_mcp_tools_expanded.py`

## Notes
- this PR supersedes the work currently split across #59 and #61
- full-repo `ruff check .` still reports existing unrelated test-style violations outside this branch

Closes #58
Closes #60
Closes #62